### PR TITLE
On debian, $0 reported "-bash" not "bash", even when properly sourced

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -8,7 +8,7 @@ if [ "$SHELL" != "/bin/bash" ]; then
     exit 1
 fi
 
-if [ "$0" != "bash" ]; then
+if [ "$0" != "bash" -a "$0" != "-bash" ]; then
     echo ERROR: This scripted should be sourced from bash:
     echo
     echo source $BASH_SOURCE


### PR DESCRIPTION
garth@debian:~/nerves-sdk$ source ./nerves-env.sh
ERROR: This scripted should be sourced from bash:
# note, $0 is "-bash" not "bash" on Debian 7.4
