### PR TITLE
remove incompatibility with older 'basename' utility 

### DIFF
--- a/board/ag150/syslinux.cfg
+++ b/board/ag150/syslinux.cfg
@@ -13,9 +13,9 @@ INCLUDE default.cfg
 
 LABEL Linux-A
   KERNEL /bzImage.a
-  APPEND root=/dev/sda2 rootwait console=ttyS0,115200 -u
+  APPEND root=/dev/sda2 rootfstype=ext4 rootwait console=ttyS0,115200 -u
 
 LABEL Linux-B
   KERNEL /bzImage.b
-  APPEND root=/dev/sda3 rootwait console=ttyS0,115200 -u
+  APPEND root=/dev/sda3 rootfstype=ext4 rootwait console=ttyS0,115200 -u
 

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v0.1.2
+ERLINIT_VERSION = f8d704fdef76c98c96ef7fd814401b8c7ebf4da0
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 


### PR DESCRIPTION
Prior to basename v8.20, the -s option didn't exist, and previous versions used a syntax where the suffix followed the filename instead.  Since this is still supported even on new versions of basename, I changed the script to allow older versions of basename to work (which still ships even the latest debian 7.3 for instance).
