### PR TITLE
Update alix fwup.conf to refer to the alix syslinux.cfg template

### DIFF
--- a/board/alix/fwup.conf
+++ b/board/alix/fwup.conf
@@ -51,7 +51,7 @@ file-resource bootpart.bin {
     host-path = "${NERVES_ROOT}/buildroot/output/images/bootpart.bin"
 }
 file-resource syslinux.cfg {
-    host-path = "${NERVES_ROOT}/board/ag150/syslinux.cfg"
+    host-path = "${NERVES_ROOT}/board/alix/syslinux.cfg"
 }
 file-resource bzImage {
     host-path = "${NERVES_ROOT}/buildroot/output/images/bzImage"


### PR DESCRIPTION
Hi,

I think there may be a minor typo in the alix fwup.conf file - seems like the alix config should be referring to the alix syslinux.cfg file.

Cheers
