### PR TITLE
Pull in all Raspberry Pi related patches from upstream

### DIFF
--- a/patches/buildroot/0013-raspberrypi-combined-update.patch
+++ b/patches/buildroot/0013-raspberrypi-combined-update.patch
@@ -1,0 +1,970 @@
+From b3addd2d5daf965cb70a47e3d00b0bb2f5321fb8 Mon Sep 17 00:00:00 2001
+From: Peter Seiderer <ps.report@gmx.net>
+Date: Sun, 4 Dec 2016 00:11:32 +0100
+Subject: [PATCH 13/13] raspberrypi combined update
+
+This includes the following patches from upstream Buildroot:
+
+raspberrypi0_defconfig: bump kernel version to 4.4.36
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+raspberrypi_defconfig: bump kernel version to 4.4.36
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+raspberrypi2_defconfig: bump kernel version to 4.4.36
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+raspberrypi3_defconfig: bump kernel version to 4.4.36
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+rpi-firmware: bump version
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+rpi-userland: bump version
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+raspberrypi-usbboot: new package
+
+This new package currently installs the "rpiboot" utility, which is
+needed to access via USB mass storage the built-in eMMC of Raspberry Pi
+compute modules.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+raspberrypi0_defconfig: bump kernel version to 4.4.43
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+raspberrypi_defconfig: bump kernel version to 4.4.43
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+raspberrypi2_defconfig: bump kernel version to 4.4.43
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+raspberrypi3_defconfig: bump kernel version to 4.4.43
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+rpi-firmware: bump version
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+rpi-userland: bump version
+
+Signed-off-by: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+board: raspberrypi: use regular kernel image
+
+Since release 4.4 a kernel without a trailer is assumed to be device tree
+capable. Since our Raspberry Pi defconfigs all use the newer firmware we can
+just use the regular kernel image.
+
+https://www.raspberrypi.org/documentation/configuration/device-tree.md
+
+Tested on Raspberry Pi 3.
+
+Cc: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Reviewed-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+board: raspberrypi: don't generate a marked kernel
+
+We no longer use the marked kernel.
+
+Cc: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Reviewed-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+rpi-firmware: remove mkknlimg
+
+This kernel marking script is no longer used.
+
+Remove build for host as well, since it's only use was to install mkknlimg.
+
+Cc: Maxime Hadjinlian <maxime.hadjinlian@gmail.com>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Reviewed-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+
+board: raspberrypi: mention the Zero model in readme.txt
+
+Cc: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Cc: Peter Seiderer <ps.report@gmx.net>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Acked-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+---
+ board/raspberrypi/genimage-raspberrypi.cfg         |   2 +-
+ board/raspberrypi/genimage-raspberrypi0.cfg        |   2 +-
+ board/raspberrypi/genimage-raspberrypi2.cfg        |   2 +-
+ board/raspberrypi/genimage-raspberrypi3.cfg        |   2 +-
+ board/raspberrypi/post-image.sh                    |   5 -
+ board/raspberrypi/readme.txt                       |  11 +-
+ configs/raspberrypi0_defconfig                     |   2 +-
+ configs/raspberrypi2_defconfig                     |   2 +-
+ configs/raspberrypi3_defconfig                     |   2 +-
+ configs/raspberrypi_defconfig                      |   2 +-
+ package/Config.in.host                             |   1 +
+ ...001-Makefile-allow-passing-CFLAGS-LDFLAGS.patch |  28 ++
+ .../0002-Makefile-add-DESTDIR-support.patch        |  49 ++++
+ ...rk-logic-to-find-def1-def2-and-def3-files.patch | 127 +++++++++
+ package/raspberrypi-usbboot/Config.in.host         |  12 +
+ .../raspberrypi-usbboot/raspberrypi-usbboot.hash   |   2 +
+ package/raspberrypi-usbboot/raspberrypi-usbboot.mk |  21 ++
+ package/rpi-firmware/mkknlimg                      | 299 ---------------------
+ package/rpi-firmware/rpi-firmware.hash             |   2 +-
+ package/rpi-firmware/rpi-firmware.mk               |  13 +-
+ package/rpi-userland/rpi-userland.hash             |   2 +-
+ package/rpi-userland/rpi-userland.mk               |   2 +-
+ 22 files changed, 258 insertions(+), 332 deletions(-)
+ create mode 100644 package/raspberrypi-usbboot/0001-Makefile-allow-passing-CFLAGS-LDFLAGS.patch
+ create mode 100644 package/raspberrypi-usbboot/0002-Makefile-add-DESTDIR-support.patch
+ create mode 100644 package/raspberrypi-usbboot/0003-main.c-rework-logic-to-find-def1-def2-and-def3-files.patch
+ create mode 100644 package/raspberrypi-usbboot/Config.in.host
+ create mode 100644 package/raspberrypi-usbboot/raspberrypi-usbboot.hash
+ create mode 100644 package/raspberrypi-usbboot/raspberrypi-usbboot.mk
+ delete mode 100644 package/rpi-firmware/mkknlimg
+
+diff --git a/board/raspberrypi/genimage-raspberrypi.cfg b/board/raspberrypi/genimage-raspberrypi.cfg
+index 74758f5..bd5166a 100644
+--- a/board/raspberrypi/genimage-raspberrypi.cfg
++++ b/board/raspberrypi/genimage-raspberrypi.cfg
+@@ -9,7 +9,7 @@ image boot.vfat {
+       "rpi-firmware/config.txt",
+       "rpi-firmware/fixup.dat",
+       "rpi-firmware/start.elf",
+-      "kernel-marked/zImage"
++      "zImage"
+     }
+   }
+   size = 32M
+diff --git a/board/raspberrypi/genimage-raspberrypi0.cfg b/board/raspberrypi/genimage-raspberrypi0.cfg
+index a38840c..a9d4c45 100644
+--- a/board/raspberrypi/genimage-raspberrypi0.cfg
++++ b/board/raspberrypi/genimage-raspberrypi0.cfg
+@@ -7,7 +7,7 @@ image boot.vfat {
+       "rpi-firmware/config.txt",
+       "rpi-firmware/fixup.dat",
+       "rpi-firmware/start.elf",
+-      "kernel-marked/zImage"
++      "zImage"
+     }
+   }
+   size = 32M
+diff --git a/board/raspberrypi/genimage-raspberrypi2.cfg b/board/raspberrypi/genimage-raspberrypi2.cfg
+index 443c821..a3be2a3 100644
+--- a/board/raspberrypi/genimage-raspberrypi2.cfg
++++ b/board/raspberrypi/genimage-raspberrypi2.cfg
+@@ -7,7 +7,7 @@ image boot.vfat {
+       "rpi-firmware/config.txt",
+       "rpi-firmware/fixup.dat",
+       "rpi-firmware/start.elf",
+-      "kernel-marked/zImage"
++      "zImage"
+     }
+   }
+   size = 32M
+diff --git a/board/raspberrypi/genimage-raspberrypi3.cfg b/board/raspberrypi/genimage-raspberrypi3.cfg
+index baab0c4..3c9f1e5 100644
+--- a/board/raspberrypi/genimage-raspberrypi3.cfg
++++ b/board/raspberrypi/genimage-raspberrypi3.cfg
+@@ -8,7 +8,7 @@ image boot.vfat {
+       "rpi-firmware/fixup.dat",
+       "rpi-firmware/start.elf",
+       "rpi-firmware/overlays",
+-      "kernel-marked/zImage"
++      "zImage"
+     }
+   }
+   size = 32M
+diff --git a/board/raspberrypi/post-image.sh b/board/raspberrypi/post-image.sh
+index c009752..b2bb070 100755
+--- a/board/raspberrypi/post-image.sh
++++ b/board/raspberrypi/post-image.sh
+@@ -18,11 +18,6 @@ __EOF__
+ 	;;
+ esac
+ 
+-# Mark the kernel as DT-enabled
+-mkdir -p "${BINARIES_DIR}/kernel-marked"
+-${HOST_DIR}/usr/bin/mkknlimg "${BINARIES_DIR}/zImage" \
+-	"${BINARIES_DIR}/kernel-marked/zImage"
+-
+ rm -rf "${GENIMAGE_TMP}"
+ 
+ genimage                           \
+diff --git a/board/raspberrypi/readme.txt b/board/raspberrypi/readme.txt
+index 03178ff..9482693 100644
+--- a/board/raspberrypi/readme.txt
++++ b/board/raspberrypi/readme.txt
+@@ -22,6 +22,10 @@ For models A, B, A+ or B+:
+ 
+   $ make raspberrypi_defconfig
+ 
++For model Zero (model A+ in smaller form factor):
++
++  $ make raspberrypi0_defconfig
++
+ For model 2 B:
+ 
+   $ make raspberrypi2_defconfig
+@@ -53,7 +57,6 @@ After building, you should obtain this tree:
+     +-- bcm2709-rpi-2-b.dtb         [1]
+     +-- bcm2710-rpi-3-b.dtb         [1]
+     +-- boot.vfat
+-    +-- kernel-marked/zImage        [2]
+     +-- rootfs.ext4
+     +-- rpi-firmware/
+     |   +-- bootcode.bin
+@@ -61,16 +64,14 @@ After building, you should obtain this tree:
+     |   +-- config.txt
+     |   +-- fixup.dat
+     |   +-- start.elf
+-    |   `-- overlays/               [3]
++    |   `-- overlays/               [2]
+     +-- sdcard.img
+     `-- zImage
+ 
+ [1] Not all of them will be present, depending on the RaspberryPi
+     model you are using.
+ 
+-[2] This is the mkknlimg DT-marked kernel.
+-
+-[3] Only for the Raspberry Pi 3 Model (overlay pi3-miniuart-bt is needed
++[2] Only for the Raspberry Pi 3 Model (overlay pi3-miniuart-bt is needed
+     to enable the RPi3 serial console otherwise occupied by the bluetooth
+     chip). Alternative would be to disable the serial console in cmdline.txt
+     and /etc/inittab.
+diff --git a/configs/raspberrypi0_defconfig b/configs/raspberrypi0_defconfig
+index 1ad56fe..736143f 100644
+--- a/configs/raspberrypi0_defconfig
++++ b/configs/raspberrypi0_defconfig
+@@ -10,7 +10,7 @@ BR2_TOOLCHAIN_BUILDROOT_CXX=y
+ BR2_LINUX_KERNEL=y
+ BR2_LINUX_KERNEL_CUSTOM_GIT=y
+ BR2_LINUX_KERNEL_CUSTOM_REPO_URL="https://github.com/raspberrypi/linux.git"
+-BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="9669a50a3a8e4f33b4fe138277bc4407e1eab9b2"
++BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="1ebe8d4a4c96cd6a90805c74233a468854960f67"
+ BR2_LINUX_KERNEL_DEFCONFIG="bcmrpi"
+ 
+ # Build the DTBs for A/B from the kernel sources: the zero is the same
+diff --git a/configs/raspberrypi2_defconfig b/configs/raspberrypi2_defconfig
+index dd2bf8b..1ec92e7 100644
+--- a/configs/raspberrypi2_defconfig
++++ b/configs/raspberrypi2_defconfig
+@@ -13,7 +13,7 @@ BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_4=y
+ BR2_LINUX_KERNEL=y
+ BR2_LINUX_KERNEL_CUSTOM_GIT=y
+ BR2_LINUX_KERNEL_CUSTOM_REPO_URL="https://github.com/raspberrypi/linux.git"
+-BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="9669a50a3a8e4f33b4fe138277bc4407e1eab9b2"
++BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="1ebe8d4a4c96cd6a90805c74233a468854960f67"
+ BR2_LINUX_KERNEL_DEFCONFIG="bcm2709"
+ 
+ # Build the DTB from the kernel sources
+diff --git a/configs/raspberrypi3_defconfig b/configs/raspberrypi3_defconfig
+index 433c0d7..6fceaa0 100644
+--- a/configs/raspberrypi3_defconfig
++++ b/configs/raspberrypi3_defconfig
+@@ -13,7 +13,7 @@ BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_4=y
+ BR2_LINUX_KERNEL=y
+ BR2_LINUX_KERNEL_CUSTOM_GIT=y
+ BR2_LINUX_KERNEL_CUSTOM_REPO_URL="https://github.com/raspberrypi/linux.git"
+-BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="9669a50a3a8e4f33b4fe138277bc4407e1eab9b2"
++BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="1ebe8d4a4c96cd6a90805c74233a468854960f67"
+ BR2_LINUX_KERNEL_DEFCONFIG="bcm2709"
+ 
+ # Build the DTB from the kernel sources
+diff --git a/configs/raspberrypi_defconfig b/configs/raspberrypi_defconfig
+index fd2a546..6af9fb3 100644
+--- a/configs/raspberrypi_defconfig
++++ b/configs/raspberrypi_defconfig
+@@ -12,7 +12,7 @@ BR2_TOOLCHAIN_BUILDROOT_CXX=y
+ BR2_LINUX_KERNEL=y
+ BR2_LINUX_KERNEL_CUSTOM_GIT=y
+ BR2_LINUX_KERNEL_CUSTOM_REPO_URL="https://github.com/raspberrypi/linux.git"
+-BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="9669a50a3a8e4f33b4fe138277bc4407e1eab9b2 "
++BR2_LINUX_KERNEL_CUSTOM_REPO_VERSION="1ebe8d4a4c96cd6a90805c74233a468854960f67"
+ BR2_LINUX_KERNEL_DEFCONFIG="bcmrpi"
+ 
+ # Build the DTBs for A/B, A+/B+ and compute module from the kernel sources
+diff --git a/package/Config.in.host b/package/Config.in.host
+index 3b115c5..3c8998e 100644
+--- a/package/Config.in.host
++++ b/package/Config.in.host
+@@ -35,6 +35,7 @@ menu "Host utilities"
+ 	source "package/patchelf/Config.in.host"
+ 	source "package/pwgen/Config.in.host"
+ 	source "package/qemu/Config.in.host"
++	source "package/raspberrypi-usbboot/Config.in.host"
+ 	source "package/sam-ba/Config.in.host"
+ 	source "package/squashfs/Config.in.host"
+ 	source "package/sunxi-tools/Config.in.host"
+diff --git a/package/raspberrypi-usbboot/0001-Makefile-allow-passing-CFLAGS-LDFLAGS.patch b/package/raspberrypi-usbboot/0001-Makefile-allow-passing-CFLAGS-LDFLAGS.patch
+new file mode 100644
+index 0000000..cdab607
+--- /dev/null
++++ b/package/raspberrypi-usbboot/0001-Makefile-allow-passing-CFLAGS-LDFLAGS.patch
+@@ -0,0 +1,28 @@
++From 5b015e67af27679f4ca8f7f5f2f71020ec054b0c Mon Sep 17 00:00:00 2001
++From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Date: Fri, 2 Dec 2016 23:09:44 +0100
++Subject: [PATCH] Makefile: allow passing CFLAGS/LDFLAGS
++
++This might be needed to pass some custom CFLAGS/LDFLAGS when building
++rpiboot.
++
++Submitted-upstream: https://github.com/raspberrypi/usbboot/pull/2
++Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++---
++ Makefile | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/Makefile b/Makefile
++index 3e7d1e4..d9a7220 100755
++--- a/Makefile
+++++ b/Makefile
++@@ -1,5 +1,5 @@
++ rpiboot: main.c
++-	$(CC) -g -o $@ $< -lusb-1.0
+++	$(CC) -g $(CFLAGS) -o $@ $< -lusb-1.0 $(LDFLAGS)
++ 
++ install: rpiboot
++ 	cp rpiboot /usr/bin
++-- 
++2.7.4
++
+diff --git a/package/raspberrypi-usbboot/0002-Makefile-add-DESTDIR-support.patch b/package/raspberrypi-usbboot/0002-Makefile-add-DESTDIR-support.patch
+new file mode 100644
+index 0000000..c37d5a1
+--- /dev/null
++++ b/package/raspberrypi-usbboot/0002-Makefile-add-DESTDIR-support.patch
+@@ -0,0 +1,49 @@
++From 905bc741b189d67160b27551b8ad01459c2707a0 Mon Sep 17 00:00:00 2001
++From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Date: Fri, 2 Dec 2016 23:10:37 +0100
++Subject: [PATCH] Makefile: add DESTDIR support
++
++This allows installing rpiboot outside of /usr if needed.
++
++Submitted-upstream: https://github.com/raspberrypi/usbboot/pull/2
++Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++---
++ Makefile | 20 ++++++++++----------
++ 1 file changed, 10 insertions(+), 10 deletions(-)
++
++diff --git a/Makefile b/Makefile
++index d9a7220..7835b7f 100755
++--- a/Makefile
+++++ b/Makefile
++@@ -2,18 +2,18 @@ rpiboot: main.c
++ 	$(CC) -g $(CFLAGS) -o $@ $< -lusb-1.0 $(LDFLAGS)
++ 
++ install: rpiboot
++-	cp rpiboot /usr/bin
++-	mkdir -p /usr/share/rpiboot
++-	cp usbbootcode.bin /usr/share/rpiboot
++-	cp msd.elf /usr/share/rpiboot
++-	cp buildroot.elf /usr/share/rpiboot
+++	cp rpiboot $(DESTDIR)/usr/bin
+++	mkdir -p $(DESTDIR)//usr/share/rpiboot
+++	cp usbbootcode.bin $(DESTDIR)/usr/share/rpiboot
+++	cp msd.elf $(DESTDIR)/usr/share/rpiboot
+++	cp buildroot.elf $(DESTDIR)/usr/share/rpiboot
++ 
++ uninstall:
++-	rm -f /usr/bin/rpiboot
++-	rm -f /usr/share/rpiboot/usbbootcode.bin
++-	rm -f /usr/share/rpiboot/msd.elf
++-	rm -f /usr/share/rpiboot/buildroot.elf
++-	rmdir --ignore-fail-on-non-empty /usr/share/rpiboot/
+++	rm -f $(DESTDIR)/usr/bin/rpiboot
+++	rm -f $(DESTDIR)/usr/share/rpiboot/usbbootcode.bin
+++	rm -f $(DESTDIR)/usr/share/rpiboot/msd.elf
+++	rm -f $(DESTDIR)/usr/share/rpiboot/buildroot.elf
+++	rmdir --ignore-fail-on-non-empty $(DESTDIR)/usr/share/rpiboot/
++ 
++ clean: 
++ 	rm rpiboot
++-- 
++2.7.4
++
+diff --git a/package/raspberrypi-usbboot/0003-main.c-rework-logic-to-find-def1-def2-and-def3-files.patch b/package/raspberrypi-usbboot/0003-main.c-rework-logic-to-find-def1-def2-and-def3-files.patch
+new file mode 100644
+index 0000000..30cde49
+--- /dev/null
++++ b/package/raspberrypi-usbboot/0003-main.c-rework-logic-to-find-def1-def2-and-def3-files.patch
+@@ -0,0 +1,127 @@
++From 935894908dc24acda0acea7d211a9d80e55ecadb Mon Sep 17 00:00:00 2001
++From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Date: Fri, 2 Dec 2016 23:43:23 +0100
++Subject: [PATCH] main.c: rework logic to find def1, def2 and def3 files
++
++The current logic to find def1, def2 and def3 first tries to find them
++in the local directory, and if they are not available, find them in
++/usr/share.
++
++However, this doesn't work if rpiboot and its related files are
++installed, but not in /usr. In order to address this use-case, this
++commit reworks the logic to find the file path.
++
++A new function, getfilepath() is created. If the requested file is
++available in the current directory, it is used. If not, then the path to
++the file is inferred from the location of the currently running
++program. I.e if we run /home/foo/sys/bin/rpiboot, then we will search
++def1 in usbbootcode.bin in
++/home/foo/sys/bin/../share/rpiboot/usbbootcode.bin.
++
++This continues to address the case of an installation in /usr, while
++allowing installation in other locations as well.
++
++Submitted-upstream: https://github.com/raspberrypi/usbboot/pull/2
++Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++---
++ main.c | 61 ++++++++++++++++++++++++++++++++++++++++++++++++-------------
++ 1 file changed, 48 insertions(+), 13 deletions(-)
++
++diff --git a/main.c b/main.c
++index 1b4e042..7c571d6 100755
++--- a/main.c
+++++ b/main.c
++@@ -1,10 +1,12 @@
++-#include "libusb-1.0/libusb.h"
+++#define _GNU_SOURCE
++ #include <stdio.h>
++ #include <stdlib.h>
++ #include <string.h>
++-
+++#include <libgen.h>
++ #include <unistd.h>
++ 
+++#include "libusb-1.0/libusb.h"
+++
++ int verbose = 0;
++ int out_ep = 1;
++ int in_ep = 2;
++@@ -146,6 +148,37 @@ int ep_read(unsigned char *buf, int len, libusb_device_handle * usb_device)
++ 	return len;
++ }
++ 
+++char *getfilepath(char *filename)
+++{
+++	char *progpath, *filepath, *progdir;
+++	ssize_t len;
+++
+++	/* If file is available locally, use it */
+++	if (access(filename, F_OK) != -1)
+++		return filename;
+++
+++	/* Otherwise, use the installed version */
+++	progpath = malloc(PATH_MAX);
+++	len = readlink("/proc/self/exe", progpath, PATH_MAX - 1);
+++	if (len == -1)
+++	{
+++		free(progpath);
+++		return NULL;
+++	}
+++
+++	progpath[len] = '\0';
+++	progdir = dirname(progpath);
+++	if (asprintf(&filepath, "%s/../share/rpiboot/%s", progdir, filename) < 0)
+++	{
+++		free(progpath);
+++		return NULL;
+++	}
+++
+++	free(progpath);
+++
+++	return filepath;
+++}
+++
++ int main(int argc, char *argv[])
++ {
++ 	int result;
++@@ -157,13 +190,9 @@ int main(int argc, char *argv[])
++ 	int last_serial = -1;
++ 	FILE *fp1, *fp2, *fp;
++ 
++-	char def1_inst[] = "/usr/share/rpiboot/usbbootcode.bin";
++-	char def2_inst[] = "/usr/share/rpiboot/msd.elf";
++-	char def3_inst[] = "/usr/share/rpiboot/buildroot.elf";
++-
++-	char def1_loc[] = "./usbbootcode.bin";
++-	char def2_loc[] = "./msd.elf";
++-	char def3_loc[] = "./buildroot.elf";
+++	char def1_name[] = "usbbootcode.bin";
+++	char def2_name[] = "msd.elf";
+++	char def3_name[] = "buildroot.elf";
++ 
++ 	char *def1, *def2, *def3;
++ 
++@@ -171,10 +200,16 @@ int main(int argc, char *argv[])
++ 	char *fatimage = NULL, *executable = NULL;
++ 	int loop       = 0;
++ 
++-// if local file version exists use it else use installed
++-	if( access( def1_loc, F_OK ) != -1 ) { def1 = def1_loc; } else { def1 = def1_inst; }
++-	if( access( def2_loc, F_OK ) != -1 ) { def2 = def2_loc; } else { def2 = def2_inst; }
++-	if( access( def3_loc, F_OK ) != -1 ) { def3 = def3_loc; } else { def3 = def3_inst; }
+++	def1 = getfilepath(def1_name);
+++	def2 = getfilepath(def2_name);
+++	def3 = getfilepath(def3_name);
+++
+++	if (!def1 || !def2 || !def3)
+++	{
+++		fprintf(stderr, "One of %s, %s or %s cannot be found\n",
+++			def1_name, def2_name, def3_name);
+++		exit(1);
+++	}
++ 
++ 	stage1   = def1;
++ 	stage2   = def2;
++-- 
++2.7.4
++
+diff --git a/package/raspberrypi-usbboot/Config.in.host b/package/raspberrypi-usbboot/Config.in.host
+new file mode 100644
+index 0000000..dce2fcc
+--- /dev/null
++++ b/package/raspberrypi-usbboot/Config.in.host
+@@ -0,0 +1,12 @@
++config BR2_PACKAGE_HOST_RASPBERRYPI_USBBOOT
++	bool "host raspberrypi-usbboot"
++	depends on BR2_arm
++	help
++	  This package builds and install the "rpiboot" tool for the
++	  host machine. This tool allows to boot the Broadcom BCM
++	  processor used in the RaspberryPi to boot over USB, and have
++	  it expose a USB mass storage device in order to reflash the
++	  built-in storage of the RaspberryPi (useful for the eMMC
++	  built into the Compute module).
++
++	  https://github.com/raspberrypi/usbboot
+diff --git a/package/raspberrypi-usbboot/raspberrypi-usbboot.hash b/package/raspberrypi-usbboot/raspberrypi-usbboot.hash
+new file mode 100644
+index 0000000..94860a9
+--- /dev/null
++++ b/package/raspberrypi-usbboot/raspberrypi-usbboot.hash
+@@ -0,0 +1,2 @@
++# Locally calculated
++sha256 a8893f8a10522bd58866eb34e7f0d7731c43200d585f122681f428cdef76e676 raspberrypi-usbboot-f4e3f0f9a3c64d846ba53ec3367e33a4f9a7d051.tar.gz
+diff --git a/package/raspberrypi-usbboot/raspberrypi-usbboot.mk b/package/raspberrypi-usbboot/raspberrypi-usbboot.mk
+new file mode 100644
+index 0000000..7018617
+--- /dev/null
++++ b/package/raspberrypi-usbboot/raspberrypi-usbboot.mk
+@@ -0,0 +1,21 @@
++################################################################################
++#
++# raspberrypi-usbboot
++#
++################################################################################
++
++RASPBERRYPI_USBBOOT_VERSION = f4e3f0f9a3c64d846ba53ec3367e33a4f9a7d051
++RASPBERRYPI_USBBOOT_SITE = $(call github,raspberrypi,usbboot,$(RASPBERRYPI_USBBOOT_VERSION))
++
++HOST_RASPBERRYPI_USBBOOT_DEPENDENCIES = host-libusb
++
++define HOST_RASPBERRYPI_USBBOOT_BUILD_CMDS
++	$(HOST_MAKE_ENV) $(MAKE) $(HOST_CONFIGURE_OPTS) -C $(@D)
++endef
++
++define HOST_RASPBERRYPI_USBBOOT_INSTALL_CMDS
++	$(HOST_MAKE_ENV) $(MAKE) $(HOST_CONFIGURE_OPTS) -C $(@D) \
++		DESTDIR=$(HOST_DIR) install
++endef
++
++$(eval $(host-generic-package))
+diff --git a/package/rpi-firmware/mkknlimg b/package/rpi-firmware/mkknlimg
+deleted file mode 100644
+index 33f8187..0000000
+--- a/package/rpi-firmware/mkknlimg
++++ /dev/null
+@@ -1,299 +0,0 @@
+-#!/usr/bin/env perl
+-#
+-# Originaly from: https://github.com/raspberrypi/tools/blob/master/mkimage/mkknlimg
+-# Original cset : f5642106425d430e1f82ee064121a5fd0e05a386
+-#
+-# ----------------------------------------------------------------------
+-# mkknlimg by Phil Elwell for Raspberry Pi
+-# based on extract-ikconfig by Dick Streefland
+-#
+-# (c) 2009,2010 Dick Streefland <dick@streefland.net>
+-# (c) 2014,2015 Raspberry Pi (Trading) Limited <info@raspberrypi.org>
+-#
+-# Licensed under the terms of the GNU General Public License.
+-# ----------------------------------------------------------------------
+-
+-use strict;
+-use warnings;
+-use integer;
+-
+-use constant FLAG_PI   => 1;
+-use constant FLAG_DTOK => 2;
+-use constant FLAG_DDTK => 4;
+-use constant FLAG_283X => 8;
+-
+-my $trailer_magic = 'RPTL';
+-
+-my $tmpfile1 = "/tmp/mkknlimg_$$.1";
+-my $tmpfile2 = "/tmp/mkknlimg_$$.2";
+-
+-my $dtok = 0;
+-my $ddtk = 0;
+-my $is_283x = 0;
+-
+-while (@ARGV && ($ARGV[0] =~ /^-/))
+-{
+-    my $arg = shift(@ARGV);
+-    if ($arg eq '--dtok')
+-    {
+-	$dtok = 1;
+-    }
+-    elsif ($arg eq '--ddtk')
+-    {
+-	$ddtk = 1;
+-    }
+-    elsif ($arg eq '--283x')
+-    {
+-	$is_283x = 1;
+-    }
+-    else
+-    {
+-	print ("* Unknown option '$arg'\n");
+-	usage();
+-    }
+-}
+-
+-usage() if (@ARGV != 2);
+-
+-my $kernel_file = $ARGV[0];
+-my $out_file = $ARGV[1];
+-
+-if (! -r $kernel_file)
+-{
+-    print ("* File '$kernel_file' not found\n");
+-    usage();
+-}
+-
+-my $wanted_configs =
+-{
+-	'CONFIG_BCM2708_DT' => FLAG_PI | FLAG_DTOK,
+-	'CONFIG_ARCH_BCM2835' => FLAG_PI | FLAG_DTOK | FLAG_283X,
+-};
+-
+-my $wanted_strings =
+-{
+-	'bcm2708_fb' => FLAG_PI,
+-	'brcm,bcm2835-mmc' => FLAG_PI,
+-	'brcm,bcm2835-sdhost' => FLAG_PI,
+-	'brcm,bcm2708-pinctrl' => FLAG_PI | FLAG_DTOK,
+-	'brcm,bcm2835-gpio' => FLAG_PI | FLAG_DTOK,
+-	'brcm,bcm2835-pm-wdt' => FLAG_PI | FLAG_DTOK | FLAG_283X,
+-	'of_overlay_apply' => FLAG_DTOK | FLAG_DDTK,
+-};
+-
+-my $res = try_extract($kernel_file, $tmpfile1);
+-$res ||= try_decompress('\037\213\010', 'xy',    'gunzip', 0,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-$res ||= try_decompress('\3757zXZ\000', 'abcde', 'unxz --single-stream', -1,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-$res ||= try_decompress('BZh',          'xy',    'bunzip2', 0,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-$res ||= try_decompress('\135\0\0\0',   'xxx',   'unlzma', 0,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-$res ||= try_decompress('\211\114\132', 'xy',    'lzop -d', 0,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-$res ||= try_decompress('\002\041\114\030', 'xy',    'lz4 -d', 1,
+-			$kernel_file, $tmpfile1, $tmpfile2);
+-
+-my $append_trailer;
+-my $trailer;
+-my $kver = '?';
+-
+-$append_trailer = $dtok;
+-
+-if ($res)
+-{
+-    $kver = $res->{'kver'} || '?';
+-    my $flags = $res->{'flags'};
+-    print("Version: $kver\n");
+-
+-    if ($flags & FLAG_PI)
+-    {
+-	$append_trailer = 1;
+-	$dtok ||= ($flags & FLAG_DTOK) != 0;
+-	$is_283x ||= ($flags & FLAG_283X) != 0;
+-	$ddtk ||= ($flags & FLAG_DDTK) != 0;
+-    }
+-    else
+-    {
+-	print ("* This doesn't look like a Raspberry Pi kernel. In pass-through mode.\n");
+-    }
+-}
+-elsif (!$dtok)
+-{
+-    print ("* Is this a valid kernel? In pass-through mode.\n");
+-}
+-
+-if ($append_trailer)
+-{
+-    printf("DT: %s\n", $dtok ? "y" : "n");
+-    printf("DDT: %s\n", $ddtk ? "y" : "n");
+-    printf("283x: %s\n", $is_283x ? "y" : "n");
+-
+-    my @atoms;
+-
+-    push @atoms, [ $trailer_magic, pack('V', 0) ];
+-    push @atoms, [ 'KVer', $kver ];
+-    push @atoms, [ 'DTOK', pack('V', $dtok) ];
+-    push @atoms, [ 'DDTK', pack('V', $ddtk) ];
+-    push @atoms, [ '283x', pack('V', $is_283x) ];
+-
+-    $trailer = pack_trailer(\@atoms);
+-    $atoms[0]->[1] = pack('V', length($trailer));
+-
+-    $trailer = pack_trailer(\@atoms);
+-}
+-
+-my $ofh;
+-my $total_len = 0;
+-
+-if ($out_file eq $kernel_file)
+-{
+-    die "* Failed to open '$out_file' for append\n"
+-	if (!open($ofh, '>>', $out_file));
+-    $total_len = tell($ofh);
+-}
+-else
+-{
+-    die "* Failed to open '$kernel_file'\n"
+-	if (!open(my $ifh, '<', $kernel_file));
+-    die "* Failed to create '$out_file'\n"
+-	if (!open($ofh, '>', $out_file));
+-
+-    my $copybuf;
+-    while (1)
+-    {
+-	my $bytes = sysread($ifh, $copybuf, 64*1024);
+-	last if (!$bytes);
+-	syswrite($ofh, $copybuf, $bytes);
+-	$total_len += $bytes;
+-    }
+-    close($ifh);
+-}
+-
+-if ($trailer)
+-{
+-    # Pad to word-alignment
+-    syswrite($ofh, "\x000\x000\x000", (-$total_len & 0x3));
+-    syswrite($ofh, $trailer);
+-}
+-
+-close($ofh);
+-
+-exit($trailer ? 0 : 1);
+-
+-END {
+-	unlink($tmpfile1) if ($tmpfile1);
+-	unlink($tmpfile2) if ($tmpfile2);
+-}
+-
+-
+-sub usage
+-{
+-	print ("Usage: mkknlimg [--dtok] [--283x] <vmlinux|zImage|bzImage> <outfile>\n");
+-	exit(1);
+-}
+-
+-sub try_extract
+-{
+-	my ($knl, $tmp) = @_;
+-
+-	my $ver = `strings "$knl" | grep -a -E "^Linux version [1-9]"`;
+-
+-	return undef if (!$ver);
+-
+-	chomp($ver);
+-
+-	my $res = { 'kver'=>$ver };
+-	$res->{'flags'} = strings_to_flags($knl, $wanted_strings) |
+-			  configs_to_flags($knl, $tmp, $wanted_configs);
+-
+-	return $res;
+-}
+-
+-
+-sub try_decompress
+-{
+-	my ($magic, $subst, $zcat, $idx, $knl, $tmp1, $tmp2) = @_;
+-
+-	my $pos = `tr "$magic\n$subst" "\n$subst=" < "$knl" | grep -abo "^$subst"`;
+-	if ($pos)
+-	{
+-		chomp($pos);
+-		$pos = (split(/[\r\n]+/, $pos))[$idx];
+-		return undef if (!defined($pos));
+-		$pos =~ s/:.*[\r\n]*$//s;
+-		my $cmd = "tail -c+$pos \"$knl\" | $zcat > $tmp2 2> /dev/null";
+-		my $err = (system($cmd) >> 8);
+-		return undef if (($err != 0) && ($err != 2));
+-
+-		return try_extract($tmp2, $tmp1);
+-	}
+-
+-	return undef;
+-}
+-
+-
+-sub strings_to_flags
+-{
+-	my ($knl, $strings) = @_;
+-	my $string_pattern = '^('.join('|', keys(%$strings)).')$';
+-	my $flags = 0;
+-
+-	my @matches = `strings \"$knl\" | grep -E \"$string_pattern\"`;
+-	foreach my $match (@matches)
+-	{
+-	    chomp($match);
+-	    $flags |= $strings->{$match};
+-	}
+-
+-	return $flags;
+-}
+-
+-sub configs_to_flags
+-{
+-	my ($knl, $tmp, $configs) = @_;
+-	my $config_pattern = '^('.join('|', keys(%$configs)).')=(.*)$';
+-	my $cf1 = 'IKCFG_ST\037\213\010';
+-	my $cf2 = '0123456789';
+-	my $flags = 0;
+-
+-	my $pos = `tr "$cf1\n$cf2" "\n$cf2=" < "$knl" | grep -abo "^$cf2"`;
+-	if ($pos)
+-	{
+-		$pos =~ s/:.*[\r\n]*$//s;
+-		$pos += 8;
+-		my $err = (system("tail -c+$pos \"$knl\" | zcat > $tmp 2> /dev/null") >> 8);
+-		if (($err == 0) || ($err == 2))
+-		{
+-			if (open(my $fh, '<', $tmp))
+-			{
+-				while (my $line = <$fh>)
+-				{
+-					chomp($line);
+-					if (($line =~ /$config_pattern/) &&
+-					    (($2 eq 'y') || ($2 eq 'm')))
+-					{
+-					    $flags |= $configs->{$1};
+-					}
+-				}
+-
+-				close($fh);
+-			}
+-		}
+-	}
+-
+-	return $flags;
+-}
+-
+-sub pack_trailer
+-{
+-	my ($atoms) = @_;
+-	my $trailer = pack('VV', 0, 0);
+-	for (my $i = $#$atoms; $i>=0; $i--)
+-	{
+-		my $atom = $atoms->[$i];
+-		$trailer .= pack('a*x!4Va4', $atom->[1], length($atom->[1]), $atom->[0]);
+-	}
+-	return $trailer;
+-}
+diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
+index 6dd2163..8161d7a 100644
+--- a/package/rpi-firmware/rpi-firmware.hash
++++ b/package/rpi-firmware/rpi-firmware.hash
+@@ -1,2 +1,2 @@
+ # Locally computed
+-sha256 f7b649ac837a4a9c12a8f96962da310ca4efd6658621d89286b421b8784a4980 rpi-firmware-ad8608c08b122b2c228dba0ff5070d6e9519faf5.tar.gz
++sha256 144de63ee1999155fc1ff597630f1a13f798e597e7c4d144b8b625fa774c1f9b rpi-firmware-7f8ac8dac0b80291cbf5e56580139034a0a42070.tar.gz
+diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
+index bf5c9dd..d2cd481 100644
+--- a/package/rpi-firmware/rpi-firmware.mk
++++ b/package/rpi-firmware/rpi-firmware.mk
+@@ -4,14 +4,12 @@
+ #
+ ################################################################################
+ 
+-RPI_FIRMWARE_VERSION = ad8608c08b122b2c228dba0ff5070d6e9519faf5
++RPI_FIRMWARE_VERSION = 7f8ac8dac0b80291cbf5e56580139034a0a42070
+ RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
+ RPI_FIRMWARE_LICENSE = BSD-3c
+ RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom
+ RPI_FIRMWARE_INSTALL_IMAGES = YES
+ 
+-RPI_FIRMWARE_DEPENDENCIES += host-rpi-firmware
+-
+ ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_INSTALL_DTBS),y)
+ define RPI_FIRMWARE_INSTALL_DTB
+ 	$(INSTALL) -D -m 0644 $(@D)/boot/bcm2708-rpi-b.dtb $(BINARIES_DIR)/rpi-firmware/bcm2708-rpi-b.dtb
+@@ -46,13 +44,4 @@ define RPI_FIRMWARE_INSTALL_IMAGES_CMDS
+ 	$(RPI_FIRMWARE_INSTALL_DTB_OVERLAYS)
+ endef
+ 
+-# We have no host sources to get, since we already
+-# bundle the script we want to install.
+-HOST_RPI_FIRMWARE_SOURCE =
+-
+-define HOST_RPI_FIRMWARE_INSTALL_CMDS
+-	$(INSTALL) -D -m 0755 package/rpi-firmware/mkknlimg $(HOST_DIR)/usr/bin/mkknlimg
+-endef
+-
+ $(eval $(generic-package))
+-$(eval $(host-generic-package))
+diff --git a/package/rpi-userland/rpi-userland.hash b/package/rpi-userland/rpi-userland.hash
+index 389c1ae..24b6584 100644
+--- a/package/rpi-userland/rpi-userland.hash
++++ b/package/rpi-userland/rpi-userland.hash
+@@ -1,2 +1,2 @@
+ # Locally computed
+-sha256 bb79667d23743769dde120d35e6a4b69c633eb66e445b5bb2c06cd3e065750a2 rpi-userland-a1b89e91f393c7134b4cdc36431f863bb3333163.tar.gz
++sha256 f229c29ceae611101bf4716b112251b2f2a33cfbb6636d736deda4e1314bb9d9 rpi-userland-c139376e9bc6fbd93f777c7fc3c7d7cf2cc35122.tar.gz
+diff --git a/package/rpi-userland/rpi-userland.mk b/package/rpi-userland/rpi-userland.mk
+index 4a6eb41..4e3b4ec 100644
+--- a/package/rpi-userland/rpi-userland.mk
++++ b/package/rpi-userland/rpi-userland.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-RPI_USERLAND_VERSION = a1b89e91f393c7134b4cdc36431f863bb3333163
++RPI_USERLAND_VERSION = c139376e9bc6fbd93f777c7fc3c7d7cf2cc35122
+ RPI_USERLAND_SITE = $(call github,raspberrypi,userland,$(RPI_USERLAND_VERSION))
+ RPI_USERLAND_LICENSE = BSD-3c
+ RPI_USERLAND_LICENSE_FILES = LICENCE
+-- 
+2.7.4
+


### PR DESCRIPTION
This includes a kernel bump to 4.4.43 and bumps for rpi-userland and
rpi-firmware. Most importantly, kernels no longer need to be marked that
use device tree, so the kernel marking logic has been removed. This will
break systems, but those systems should upgrade their kernels to avoid
any mismatches between kernel patches and rpi-firmware.