### PR TITLE
fix custom logo convert command dangling paren

### DIFF
--- a/patches/buildroot/0005-Add-customizable-linux-logo.patch
+++ b/patches/buildroot/0005-Add-customizable-linux-logo.patch
@@ -117,7 +117,7 @@ index 0000000..aa0e4de
 +define CUSTOMLOGO_BUILD_CMDS
 +	convert $(BR2_PACKAGE_CUSTOMLOGO_PATH) \
 +		-dither None -colors 224 -compress none \
-+		$(@D)/logo_linux_clut224.ppm)
++		$(@D)/logo_linux_clut224.ppm
 +endef
 +endif
 +


### PR DESCRIPTION
Fixes the following error
```
convert "/nerves/env/my_custom_system/assets/images/logo.ppm" -dither None -colors 224 -compress none /nerves/build/build/customlogo/logo_linux_clut224.ppm)
/bin/bash: -c: line 0: syntax error near unexpected token `)'
```