### PR TITLE
replace permissions case implementation with awk

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -23,33 +23,11 @@ else
     STAT=stat
 fi
 
-# This implementation could be improved.
-# The list below hits the combinations that I see.
+# Implementation from: https://unix.stackexchange.com/a/9518
+
 perm_to_num() {
-    case $1 in
-        ?rwsr-xr-x) echo "4755" ;;
-        ?rws--x--x) echo "4711" ;;
-        ?rwxrwxrwt) echo "1777" ;;
-        ?rwxrwxrwx) echo "777" ;;
-        ?rwxrwxr-x) echo "775" ;;
-        ?rwxrwx---) echo "770" ;;
-        ?rwxr-xr-x) echo "755" ;;
-        ?rwxr-x---) echo "750" ;;
-        ?rwx------) echo "700" ;;
-        ?rw-rw-rw-) echo "666" ;;
-        ?rw-rw-r--) echo "664" ;;
-        ?rw-rw----) echo "660" ;;
-        ?rw-r--r--) echo "644" ;;
-        ?rw--w--w-) echo "622" ;;
-        ?rw-------) echo "600" ;;
-        ?r-xr-xr-x) echo "555" ;;
-        ?r-xr-x---) echo "550" ;;
-        ?r-x------) echo "500" ;;
-        ?r--r--r--) echo "444" ;;
-        ?r--r-----) echo "440" ;;
-        ?r--------) echo "400" ;;
-        *) echo "huh"
-    esac
+    echo $1 | awk "{k=0; for(i=0;i<=8;i++) k+=((substr(\$1,i+2,1)~/[rwx]/)*2^(8-i));
+            if (k) printf(\"%0o\",k)}"
 }
 
 owner_to_uid_gid() {


### PR DESCRIPTION
The case implementation broke when adding the `sudo' buildroot package, when a folder had permission is drwx--x--x. 
This awk implementation works.