### PR TITLE
Revert "replace permissions case implementation with awk"

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -23,11 +23,33 @@ else
     STAT=stat
 fi
 
-# Implementation from: https://unix.stackexchange.com/a/9518
-
+# This implementation could be improved.
+# The list below hits the combinations that I see.
 perm_to_num() {
-    echo $1 | awk "{k=0; for(i=0;i<=8;i++) k+=((substr(\$1,i+2,1)~/[rwx]/)*2^(8-i));
-            if (k) printf(\"%0o\",k)}"
+    case $1 in
+        ?rwsr-xr-x) echo "4755" ;;
+        ?rws--x--x) echo "4711" ;;
+        ?rwxrwxrwt) echo "1777" ;;
+        ?rwxrwxrwx) echo "777" ;;
+        ?rwxrwxr-x) echo "775" ;;
+        ?rwxrwx---) echo "770" ;;
+        ?rwxr-xr-x) echo "755" ;;
+        ?rwxr-x---) echo "750" ;;
+        ?rwx------) echo "700" ;;
+        ?rw-rw-rw-) echo "666" ;;
+        ?rw-rw-r--) echo "664" ;;
+        ?rw-rw----) echo "660" ;;
+        ?rw-r--r--) echo "644" ;;
+        ?rw--w--w-) echo "622" ;;
+        ?rw-------) echo "600" ;;
+        ?r-xr-xr-x) echo "555" ;;
+        ?r-xr-x---) echo "550" ;;
+        ?r-x------) echo "500" ;;
+        ?r--r--r--) echo "444" ;;
+        ?r--r-----) echo "440" ;;
+        ?r--------) echo "400" ;;
+        *) echo "huh"
+    esac
 }
 
 owner_to_uid_gid() {


### PR DESCRIPTION
Reverts nerves-project/nerves_system_br#97

The following strings do not work:
`-rwsr-xr-x` should be "4755" but I get "655"
`-rws--x--x` should be "4711" but I get "611"
`-rwxrwxrwt` should be "1777" but I get "776"

Looking at the patch again, it's more obvious that the special bits aren't handled. Therefore, I need to revert it for now. 
