### PR TITLE
Update for Elixir 1.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Nerves.System.BR.Mixfile do
 
 @version Path.join(__DIR__, "VERSION")
          |> File.read!
-         |> String.strip
+         |> String.trim
 
   def project do
     [app: :nerves_system_br,

--- a/nerves.exs
+++ b/nerves.exs
@@ -3,7 +3,7 @@ use Mix.Config
 version =
   Path.join(__DIR__, "VERSION")
   |> File.read!
-  |> String.strip
+  |> String.trim
 
 config :nerves_system_br, :nerves_env,
   type: :system_platform,


### PR DESCRIPTION
`String.strip` was deprecated in favor of `String.trim`