### PR TITLE
Update rpi-userland and rpi-firmware SHAs

### DIFF
--- a/patches/buildroot/0012-Raspberry-Pi-Zero-W-combined-update.patch
+++ b/patches/buildroot/0012-Raspberry-Pi-Zero-W-combined-update.patch
@@ -1,4 +1,4 @@
-From 9d344f60930256ebd5abb753f5a073fdef242827 Mon Sep 17 00:00:00 2001
+From 1fcf4a730045225b20e94394a0f63ff99f4c852c Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Wed, 29 Mar 2017 08:59:03 -0400
 Subject: [PATCH] Raspberry Pi Zero W combined update
@@ -106,13 +106,13 @@ index c54080d..392bff3 100644
  
  # Build the DTBs for A/B, A+/B+ and compute module from the kernel sources
 diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
-index 11655ee..b63ea98 100644
+index 11655ee..f4a23c4 100644
 --- a/package/rpi-firmware/rpi-firmware.hash
 +++ b/package/rpi-firmware/rpi-firmware.hash
 @@ -1,2 +1,2 @@
  # Locally computed
 -sha256 84f44265c7e9bfe3e54a326b95ea7067870cfe08a9aae12f00aec8d47f6fc353 rpi-firmware-4b24a81a2ce94afd4458d1af4ea1e73d58e69848.tar.gz
-+sha256 173c55441a78b5ce9cd7739318f71361b7569597e409c0e002c71e0fd6909481 rpi-firmware-b51046a2b2bb69771579a549d157205d9982f858.tar.gz
++sha256 2d2775bcfecd92aec06685efb7461258e996cfbfc6ce9b8a791b73883c7fee4f rpi-firmware-b51046a2b2bb69771579a549d157205d9982f858.tar.gz
 diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
 index 134fceb..f7702df 100644
 --- a/package/rpi-firmware/rpi-firmware.mk
@@ -127,13 +127,13 @@ index 134fceb..f7702df 100644
  RPI_FIRMWARE_LICENSE = BSD-3-Clause
  RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom
 diff --git a/package/rpi-userland/rpi-userland.hash b/package/rpi-userland/rpi-userland.hash
-index d4715fe..3e0dbfa 100644
+index d4715fe..7586366 100644
 --- a/package/rpi-userland/rpi-userland.hash
 +++ b/package/rpi-userland/rpi-userland.hash
 @@ -1,2 +1,2 @@
  # Locally computed
 -sha256 35b02340de04d8b91490e192b402ba23333a82b0c624e3e4475ba3240a2419a5 rpi-userland-f0642e3b58d8a140a3f7621630c15fbfa794b19d.tar.gz
-+sha256 9f7caa5fee77cef034551b23a7c12d78792ebd2feca7bcbc677da4daf2a98cf7 rpi-userland-f410ec051a3724934e3671315474d4b81424b0ef.tar.gz
++sha256 e526cc9f1aa5a23d879d51dea6c9b6c092ba933c124a374e4c9a44e75fdd27d7 rpi-userland-f410ec051a3724934e3671315474d4b81424b0ef.tar.gz
 diff --git a/package/rpi-userland/rpi-userland.mk b/package/rpi-userland/rpi-userland.mk
 index ab05447..632552c 100644
 --- a/package/rpi-userland/rpi-userland.mk


### PR DESCRIPTION
These both magically changed even though their tarball's contents stayed
the same. Presumably Github changed their tar.gz compression settings.

This fixes #109.