### PR TITLE
Make Elixir version printout more robust

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -71,14 +71,16 @@ else
     # Found it. Print out some useful information so that the user can
     # easily figure out whether the wrong nerves installation was used.
     NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= $NERVES_SYSTEM/.config | sed -e 's/BR2_DEFCONFIG="\(.*\)"/\1/')
-    NERVES_ELIXIR_VERSION_FILE=$(dirname $(readlink_f $(which iex)))/../VERSION
 
     echo "Shell environment updated for Nerves"
     echo
     echo "Nerves configuration: $NERVES_DEFCONFIG"
     echo "Cross-compiler prefix: $(basename $CROSSCOMPILE)"
     echo "Erlang/OTP release on target: $NERVES_TARGET_ERL_VER"
-    if [ -e $NERVES_ELIXIR_VERSION_FILE ]; then
-        echo "Elixir version: $(cat $NERVES_ELIXIR_VERSION_FILE)"
+    if [ -n "$(which elixir)" ]; then
+        NERVES_ELIXIR_VERSION=$(elixir -v | grep lixir | cut -d' ' -f2-)
+        echo "Elixir version (from path): $NERVES_ELIXIR_VERSION"
+    else
+        echo "WARNING: Elixir not found on host"
     fi
 fi


### PR DESCRIPTION
While most people don't use nerves-env.sh, for the ones that do, knowing
the Elixir version is helpful. This calls elixir to get its version
rather than trying to derive it. The script to derive it only worked
if you manually built Elixir.