### PR TITLE
nbtty: bump to v0.3.2

### DIFF
--- a/package/nbtty/nbtty.hash
+++ b/package/nbtty/nbtty.hash
@@ -1,2 +1,2 @@
 # Locally computed:
-sha256  fd8558af6fd1e808dc048ce468128dd114e7e88fc7a5fa75c95475bbf7b36b4b  nbtty-v0.3.0.tar.gz
+sha256  56d8be9069fc8745b6ef1886516d382079a9057962041626e46dfb95160c2f02  nbtty-v0.3.2.tar.gz

--- a/package/nbtty/nbtty.mk
+++ b/package/nbtty/nbtty.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-NBTTY_VERSION = v0.3.0
+NBTTY_VERSION = v0.3.2
 NBTTY_SITE = $(call github,fhunleth,nbtty,$(NBTTY_VERSION))
 NBTTY_LICENSE = GPL-2.0+
 NBTTY_LICENSE_FILES = COPYING


### PR DESCRIPTION
This reduces ANSI escape sequence traffic over the serial port to make things print a little faster especially when dumping logs.