### PR TITLE
erlang: bump to 20.3.1

### DIFF
--- a/patches/buildroot/0010-erlang-bump-to-otp-20.3.1.patch
+++ b/patches/buildroot/0010-erlang-bump-to-otp-20.3.1.patch
@@ -1,7 +1,7 @@
-From cd525b4cf204133622f8fbdcae4c74a0141d783a Mon Sep 17 00:00:00 2001
+From 75c534b82da22254a595141cf6d1456008b4b876 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Fri, 7 Jul 2017 18:23:51 -0400
-Subject: [PATCH] erlang: bump to otp 20.3
+Subject: [PATCH] erlang: bump to otp 20.3.1
 
 ---
  package/erlang/0001-build-fix.patch                | 13 ----
@@ -389,7 +389,7 @@ index ad0bb6b..0000000
 -2.14.1
 -
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index cf820ce..37a751d 100644
+index cf820ce..247726b 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,3 +1,2 @@
@@ -397,9 +397,9 @@ index cf820ce..37a751d 100644
 -md5     2faed2c3519353e6bc2501ed4d8e6ae7        otp_src_20.0.tar.gz
 -sha256  fe80e1e14a2772901be717694bb30ac4e9a07eee0cc7a28988724cbd21476811        otp_src_20.0.tar.gz
 +# sha256 locally computed
-+sha256  e73a9b2c2a16f3739aa642b2a8698c56939e9b0d3664bb92bd9fc51a7308d73e        OTP-20.3.tar.gz
++sha256  8b8a75dc370799600e74bb0368ad69c528a03b505e088c9d2c55b34bf861dde6  OTP-20.3.1.tar.gz
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 4b29969..b813b00 100644
+index 4b29969..e392e6a 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,21 +5,18 @@
@@ -410,7 +410,7 @@ index 4b29969..b813b00 100644
 -ERLANG_SITE = http://www.erlang.org/download
 -ERLANG_SOURCE = otp_src_$(ERLANG_VERSION).tar.gz
 -ERLANG_DEPENDENCIES = host-erlang
-+ERLANG_VERSION = 20.3
++ERLANG_VERSION = 20.3.1
 +ERLANG_SITE = https://github.com/erlang/otp/archive
 +ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
 +ERLANG_DEPENDENCIES = host-erlang host-autoconf


### PR DESCRIPTION
This fixes a regression in 20.3.1 with the ssl application.