### PR TITLE
Support the Raspberry Pi 3 B+

### DIFF
--- a/patches/buildroot/0010-erlang-bump-to-otp-20.3.2.patch
+++ b/patches/buildroot/0010-erlang-bump-to-otp-20.3.2.patch
@@ -1,7 +1,7 @@
-From 75c534b82da22254a595141cf6d1456008b4b876 Mon Sep 17 00:00:00 2001
+From d5b65ed55b2b4a3e498b5d4bc26fd5a29c24cea5 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Fri, 7 Jul 2017 18:23:51 -0400
-Subject: [PATCH] erlang: bump to otp 20.3.1
+Subject: [PATCH] erlang: bump to otp 20.3.2
 
 ---
  package/erlang/0001-build-fix.patch                | 13 ----
@@ -389,7 +389,7 @@ index ad0bb6b..0000000
 -2.14.1
 -
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index cf820ce..247726b 100644
+index cf820ce..77aea9e 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,3 +1,2 @@
@@ -397,9 +397,9 @@ index cf820ce..247726b 100644
 -md5     2faed2c3519353e6bc2501ed4d8e6ae7        otp_src_20.0.tar.gz
 -sha256  fe80e1e14a2772901be717694bb30ac4e9a07eee0cc7a28988724cbd21476811        otp_src_20.0.tar.gz
 +# sha256 locally computed
-+sha256  8b8a75dc370799600e74bb0368ad69c528a03b505e088c9d2c55b34bf861dde6  OTP-20.3.1.tar.gz
++sha256  9809be52baa23d6fd18ee70b9a9b7c548e44f586db2f46ff5bfe66719cfab10a  OTP-20.3.2.tar.gz
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 4b29969..e392e6a 100644
+index 4b29969..338c850 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,21 +5,18 @@
@@ -410,7 +410,7 @@ index 4b29969..e392e6a 100644
 -ERLANG_SITE = http://www.erlang.org/download
 -ERLANG_SOURCE = otp_src_$(ERLANG_VERSION).tar.gz
 -ERLANG_DEPENDENCIES = host-erlang
-+ERLANG_VERSION = 20.3.1
++ERLANG_VERSION = 20.3.2
 +ERLANG_SITE = https://github.com/erlang/otp/archive
 +ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
 +ERLANG_DEPENDENCIES = host-erlang host-autoconf

--- a/patches/buildroot/0011-linux-add-BR2_LINUX_KERNEL_NEEDS_HOST_LIBELF.patch
+++ b/patches/buildroot/0011-linux-add-BR2_LINUX_KERNEL_NEEDS_HOST_LIBELF.patch
@@ -1,4 +1,4 @@
-From 2756f7c7ae2082ca0b742cb2ece770198789d30e Mon Sep 17 00:00:00 2001
+From 6604639c15679d6fc9b3831f1f3fa1f8390670b9 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Mon, 5 Mar 2018 13:59:05 -0500
 Subject: [PATCH] linux: add BR2_LINUX_KERNEL_NEEDS_HOST_LIBELF

--- a/patches/buildroot/0011-rpi-firmware-support-kernel-selection.patch
+++ b/patches/buildroot/0011-rpi-firmware-support-kernel-selection.patch
@@ -1,13 +1,13 @@
-From 4c614459c296edbd8093a19131b2912e7f2cbe7d Mon Sep 17 00:00:00 2001
+From c46840e37459c4605225a776e0599c459d97cdd9 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Wed, 29 Mar 2017 08:59:03 -0400
 Subject: [PATCH] rpi-firmware: support kernel selection
 
 ---
  package/rpi-firmware/Config.in         | 18 ++++++++++++++++++
- package/rpi-firmware/rpi-firmware.hash |  1 +
- package/rpi-firmware/rpi-firmware.mk   |  7 +++++--
- 3 files changed, 24 insertions(+), 2 deletions(-)
+ package/rpi-firmware/rpi-firmware.hash |  3 ++-
+ package/rpi-firmware/rpi-firmware.mk   |  9 ++++++---
+ 3 files changed, 26 insertions(+), 4 deletions(-)
 
 diff --git a/package/rpi-firmware/Config.in b/package/rpi-firmware/Config.in
 index 0ebbe7a..2b8feaf 100644
@@ -39,25 +39,27 @@ index 0ebbe7a..2b8feaf 100644
  	default BR2_PACKAGE_RPI_FIRMWARE_DEFAULT
  	help
 diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
-index 833a7fb..6ae0e12 100644
+index 833a7fb..0414463 100644
 --- a/package/rpi-firmware/rpi-firmware.hash
 +++ b/package/rpi-firmware/rpi-firmware.hash
 @@ -1,2 +1,3 @@
  # Locally computed
- sha256 0451e1a843bf02df81126a1625d9a15dfdf19dcb2f9e95b0613a63e59fd31ca8 rpi-firmware-2067241bc7cdf238fdeab7f5a3c22faa57dd5617.tar.gz
+-sha256 0451e1a843bf02df81126a1625d9a15dfdf19dcb2f9e95b0613a63e59fd31ca8 rpi-firmware-2067241bc7cdf238fdeab7f5a3c22faa57dd5617.tar.gz
 +sha256 2d2775bcfecd92aec06685efb7461258e996cfbfc6ce9b8a791b73883c7fee4f rpi-firmware-b51046a2b2bb69771579a549d157205d9982f858.tar.gz
++sha256 0ad8b66c02ba14917dfdc15f11d702da650c473681d100efb3f8d47aee9b8ece rpi-firmware-b1a7f4aea6cbd380319c2849ecc5988f9a4dba70.tar.gz
 diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
-index 22eaaa2..a801fd2 100644
+index 22eaaa2..681d856 100644
 --- a/package/rpi-firmware/rpi-firmware.mk
 +++ b/package/rpi-firmware/rpi-firmware.mk
 @@ -4,7 +4,12 @@
  #
  ################################################################################
  
+-RPI_FIRMWARE_VERSION = 2067241bc7cdf238fdeab7f5a3c22faa57dd5617
 +ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_KERNEL_4_4),y)
 +RPI_FIRMWARE_VERSION = b51046a2b2bb69771579a549d157205d9982f858
 +else
- RPI_FIRMWARE_VERSION = 2067241bc7cdf238fdeab7f5a3c22faa57dd5617
++RPI_FIRMWARE_VERSION = b1a7f4aea6cbd380319c2849ecc5988f9a4dba70
 +endif
 +
  RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))

--- a/patches/buildroot/0012-linux-fix-passing-of-host-CFLAGS-and-LDFLAGS.patch
+++ b/patches/buildroot/0012-linux-fix-passing-of-host-CFLAGS-and-LDFLAGS.patch
@@ -1,4 +1,4 @@
-From ad8804326df075a9935a3751f61e5ad1a2865736 Mon Sep 17 00:00:00 2001
+From 95b9df5fb6c0ff13ed6bd092040b5652eb8d5a52 Mon Sep 17 00:00:00 2001
 From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 Date: Sun, 4 Mar 2018 22:31:17 +0100
 Subject: [PATCH] linux: fix passing of host CFLAGS and LDFLAGS

--- a/patches/buildroot/0013-rpi-firmware-support-kernel-selection.patch
+++ b/patches/buildroot/0013-rpi-firmware-support-kernel-selection.patch
@@ -1,4 +1,4 @@
-From c46840e37459c4605225a776e0599c459d97cdd9 Mon Sep 17 00:00:00 2001
+From 690e98689dfe6f8b2793ca6d800b78a6e912709b Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Wed, 29 Mar 2017 08:59:03 -0400
 Subject: [PATCH] rpi-firmware: support kernel selection

--- a/patches/buildroot/0014-rpi-firmware-support-rpi-b-plus.patch
+++ b/patches/buildroot/0014-rpi-firmware-support-rpi-b-plus.patch
@@ -1,7 +1,7 @@
-From 6824cbf2633a0e2abf0334de7b8b1abff240d9d7 Mon Sep 17 00:00:00 2001
+From c6df43a3da93fcf2901b15eb731e3191e017d607 Mon Sep 17 00:00:00 2001
 From: Justin Schneck <jschneck@mac.com>
 Date: Wed, 21 Mar 2018 15:12:29 -0400
-Subject: [PATCH 14/14] rpi-firmware support rpi-b-plus
+Subject: [PATCH] rpi-firmware: support rpi-b-plus
 
 ---
  package/rpi-firmware/rpi-firmware.hash | 2 +-

--- a/patches/buildroot/0014-rpi-firmware-support-rpi-b-plus.patch
+++ b/patches/buildroot/0014-rpi-firmware-support-rpi-b-plus.patch
@@ -1,0 +1,35 @@
+From 6824cbf2633a0e2abf0334de7b8b1abff240d9d7 Mon Sep 17 00:00:00 2001
+From: Justin Schneck <jschneck@mac.com>
+Date: Wed, 21 Mar 2018 15:12:29 -0400
+Subject: [PATCH 14/14] rpi-firmware support rpi-b-plus
+
+---
+ package/rpi-firmware/rpi-firmware.hash | 2 +-
+ package/rpi-firmware/rpi-firmware.mk   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
+index 0414463..77a4f27 100644
+--- a/package/rpi-firmware/rpi-firmware.hash
++++ b/package/rpi-firmware/rpi-firmware.hash
+@@ -1,3 +1,3 @@
+ # Locally computed
+ sha256 2d2775bcfecd92aec06685efb7461258e996cfbfc6ce9b8a791b73883c7fee4f rpi-firmware-b51046a2b2bb69771579a549d157205d9982f858.tar.gz
+-sha256 0ad8b66c02ba14917dfdc15f11d702da650c473681d100efb3f8d47aee9b8ece rpi-firmware-b1a7f4aea6cbd380319c2849ecc5988f9a4dba70.tar.gz
++sha256 a1f0db0fa87879588a39625e1b196c01e81dcf19f5f254b219e5b57047c3513e rpi-firmware-3347884c7df574bbabeff6dca63caf686e629699.tar.gz
+diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
+index 681d856..9ce4a26 100644
+--- a/package/rpi-firmware/rpi-firmware.mk
++++ b/package/rpi-firmware/rpi-firmware.mk
+@@ -7,7 +7,7 @@
+ ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_KERNEL_4_4),y)
+ RPI_FIRMWARE_VERSION = b51046a2b2bb69771579a549d157205d9982f858
+ else
+-RPI_FIRMWARE_VERSION = b1a7f4aea6cbd380319c2849ecc5988f9a4dba70
++RPI_FIRMWARE_VERSION = 3347884c7df574bbabeff6dca63caf686e629699
+ endif
+ 
+ RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
+-- 
+2.7.4
+

--- a/patches/buildroot/0015-package-rpi-firmware-improve-installation-of-dtb-fil.patch
+++ b/patches/buildroot/0015-package-rpi-firmware-improve-installation-of-dtb-fil.patch
@@ -1,0 +1,34 @@
+From e243db6f3508ec1c61ec903d0bbf731e40fa00ed Mon Sep 17 00:00:00 2001
+From: Martin Bark <martin@barkynet.com>
+Date: Sat, 24 Mar 2018 14:10:14 +0000
+Subject: [PATCH] package/rpi-firmware: improve installation of dtb files
+
+Don't list specific dtb files, instead install all dtb files in the same
+way as dtbo files are currently done.
+
+Signed-off-by: Martin Bark <martin@barkynet.com>
+---
+ package/rpi-firmware/rpi-firmware.mk | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
+index 9ce4a26..2d922a6 100644
+--- a/package/rpi-firmware/rpi-firmware.mk
++++ b/package/rpi-firmware/rpi-firmware.mk
+@@ -17,10 +17,9 @@ RPI_FIRMWARE_INSTALL_IMAGES = YES
+ 
+ ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_INSTALL_DTBS),y)
+ define RPI_FIRMWARE_INSTALL_DTB
+-	$(INSTALL) -D -m 0644 $(@D)/boot/bcm2708-rpi-b.dtb $(BINARIES_DIR)/rpi-firmware/bcm2708-rpi-b.dtb
+-	$(INSTALL) -D -m 0644 $(@D)/boot/bcm2708-rpi-b-plus.dtb $(BINARIES_DIR)/rpi-firmware/bcm2708-rpi-b-plus.dtb
+-	$(INSTALL) -D -m 0644 $(@D)/boot/bcm2709-rpi-2-b.dtb $(BINARIES_DIR)/rpi-firmware/bcm2709-rpi-2-b.dtb
+-	$(INSTALL) -D -m 0644 $(@D)/boot/bcm2710-rpi-3-b.dtb $(BINARIES_DIR)/rpi-firmware/bcm2710-rpi-3-b.dtb
++	for dtb in  $(@D)/boot/*.dtb; do \
++		$(INSTALL) -D -m 0644 $${dtb} $(BINARIES_DIR)/rpi-firmware/$${dtb##*/} || exit 1; \
++	done
+ endef
+ endif
+ 
+-- 
+2.7.4
+

--- a/patches/buildroot/0016-package-rpi-bt-firmware-change-to-LibreELEC-github-r.patch
+++ b/patches/buildroot/0016-package-rpi-bt-firmware-change-to-LibreELEC-github-r.patch
@@ -1,0 +1,70 @@
+From 7179b0eb73a4e7358c4cba48818847106613c906 Mon Sep 17 00:00:00 2001
+From: Martin Bark <martin@barkynet.com>
+Date: Sat, 24 Mar 2018 14:10:15 +0000
+Subject: [PATCH] package/rpi-bt-firmware: change to LibreELEC github repo
+
+Include BCM4345C0.hcd for the rpi3 b+
+
+Signed-off-by: Martin Bark <martin@barkynet.com>
+---
+ package/rpi-bt-firmware/Config.in            |  5 +++--
+ package/rpi-bt-firmware/rpi-bt-firmware.hash |  3 ++-
+ package/rpi-bt-firmware/rpi-bt-firmware.mk   | 12 +++++++-----
+ 3 files changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/package/rpi-bt-firmware/Config.in b/package/rpi-bt-firmware/Config.in
+index dfc1cee..45643d6 100644
+--- a/package/rpi-bt-firmware/Config.in
++++ b/package/rpi-bt-firmware/Config.in
+@@ -3,6 +3,7 @@ config BR2_PACKAGE_RPI_BT_FIRMWARE
+ 	depends on BR2_arm || BR2_aarch64
+ 	help
+ 	  Raspberry Pi 3 and Zero W Broadcom BCM43438 Bluetooth module
+-	  firmware.
++	  firmware. Raspberry Pi 3 Model B+ Broadcom BCM4345C0
++	  Bluetooth module firmware.
+ 
+-	  https://aur.archlinux.org/packages/pi-bluetooth
++	  https://github.com/LibreELEC/brcmfmac_sdio-firmware-rpi
+diff --git a/package/rpi-bt-firmware/rpi-bt-firmware.hash b/package/rpi-bt-firmware/rpi-bt-firmware.hash
+index f1d06e8..553a7e4 100644
+--- a/package/rpi-bt-firmware/rpi-bt-firmware.hash
++++ b/package/rpi-bt-firmware/rpi-bt-firmware.hash
+@@ -1,2 +1,3 @@
+ # Locally computed
+-sha256 5d9c9364277414ffd67b4a266cdf88e92f28eb937e5a413750e87b7a94161bef  rpi-bt-firmware-a439f892bf549ddfefa9ba7ad1999cc515f233bf.tar.gz
++sha256 beade89c5c072158b6cf18cf741d2695980fd6a4533dab3897bebf90c0631a30  rpi-bt-firmware-18d7c931aff0a8a78360b9b9eaeb15d1224fb907.tar.gz
++sha256 b16056fc91b82a0e3e8de8f86c2dac98201aa9dc3cbd33e8d38f1b087fcec30d  LICENCE.broadcom_bcm43xx
+diff --git a/package/rpi-bt-firmware/rpi-bt-firmware.mk b/package/rpi-bt-firmware/rpi-bt-firmware.mk
+index 255da19..689b80e 100644
+--- a/package/rpi-bt-firmware/rpi-bt-firmware.mk
++++ b/package/rpi-bt-firmware/rpi-bt-firmware.mk
+@@ -4,18 +4,20 @@
+ #
+ ################################################################################
+ 
+-RPI_BT_FIRMWARE_VERSION = a439f892bf549ddfefa9ba7ad1999cc515f233bf
+-RPI_BT_FIRMWARE_SITE = https://aur.archlinux.org/pi-bluetooth.git
+-RPI_BT_FIRMWARE_SITE_METHOD = git
++RPI_BT_FIRMWARE_VERSION = 18d7c931aff0a8a78360b9b9eaeb15d1224fb907
++RPI_BT_FIRMWARE_SITE = $(call github,LibreELEC,brcmfmac_sdio-firmware-rpi,$(RPI_BT_FIRMWARE_VERSION))
+ RPI_BT_FIRMWARE_LICENSE = PROPRIETARY
+ RPI_BT_FIRMWARE_LICENSE_FILES = LICENCE.broadcom_bcm43xx
+ 
++RPI_BT_FIRMWARE_FILES = brcm/BCM43430A1.hcd BCM4345C0.hcd
++
+ # The BlueZ hciattach utility looks for firmware in /etc/firmware. Add a
+ # compatibility symlink.
+ define RPI_BT_FIRMWARE_INSTALL_TARGET_CMDS
+ 	ln -sf ../lib/firmware $(TARGET_DIR)/etc/firmware
+-	$(INSTALL) -D -m 0644 $(@D)/BCM43430A1.hcd \
+-		$(TARGET_DIR)/lib/firmware/BCM43430A1.hcd
++	for file in $(RPI_BT_FIRMWARE_FILES); do \
++		$(INSTALL) -D -m 0644 $(@D)/firmware/$${file} $(TARGET_DIR)/lib/firmware/$${file##*/}; \
++	done
+ endef
+ 
+ $(eval $(generic-package))
+-- 
+2.7.4
+

--- a/patches/buildroot/0017-package-rpi-wifi-firmware-change-to-LibreELEC-github.patch
+++ b/patches/buildroot/0017-package-rpi-wifi-firmware-change-to-LibreELEC-github.patch
@@ -1,0 +1,79 @@
+From e5dc3f8102f0adbeeed0bf143c1c30aa59bf2498 Mon Sep 17 00:00:00 2001
+From: Martin Bark <martin@barkynet.com>
+Date: Sat, 24 Mar 2018 14:10:16 +0000
+Subject: [PATCH] package/rpi-wifi-firmware: change to LibreELEC github repo
+
+Include brcmfmac43455 firmware for the rpi3 b+
+
+Signed-off-by: Martin Bark <martin@barkynet.com>
+Cc: Jens Maus <mail@jens-maus.de>
+---
+ package/rpi-wifi-firmware/Config.in              | 11 +++++++----
+ package/rpi-wifi-firmware/rpi-wifi-firmware.hash |  3 ++-
+ package/rpi-wifi-firmware/rpi-wifi-firmware.mk   | 16 +++++-----------
+ 3 files changed, 14 insertions(+), 16 deletions(-)
+
+diff --git a/package/rpi-wifi-firmware/Config.in b/package/rpi-wifi-firmware/Config.in
+index 2c87c75..7e81b28 100644
+--- a/package/rpi-wifi-firmware/Config.in
++++ b/package/rpi-wifi-firmware/Config.in
+@@ -1,10 +1,13 @@
+ config BR2_PACKAGE_RPI_WIFI_FIRMWARE
+ 	bool "rpi-wifi-firmware"
+ 	depends on BR2_arm || BR2_aarch64
+-	select BR2_PACKAGE_LINUX_FIRMWARE
+-	select BR2_PACKAGE_LINUX_FIRMWARE_BRCM_BCM43XXX # runtime
++	depends on !BR2_PACKAGE_LINUX_FIRMWARE_BRCM_BCM43XXX
+ 	help
+ 	  Raspberry Pi 3 and Zero W Broadcom BCM43430 wifi module
+-	  NVRAM data.
++	  NVRAM data. Raspberry Pi 3 Model B+ Broadcom BCM43455
++	  wifi module NVRAM data.
+ 
+-	  https://github.com/RPi-Distro/firmware-nonfree/
++	  https://github.com/LibreELEC/brcmfmac_sdio-firmware-rpi
++
++comment "rpi-wifi-firmware conflicts with linux-firmware Broadcom BRCM bcm43xx"
++	depends on BR2_PACKAGE_LINUX_FIRMWARE_BRCM_BCM43XXX
+diff --git a/package/rpi-wifi-firmware/rpi-wifi-firmware.hash b/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
+index c205065..bc0d7c8 100644
+--- a/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
++++ b/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
+@@ -1,2 +1,3 @@
+ # Locally calculated
+-sha256  872fde4f9942d9aba805880d6eaddfe050305626fd58ad955bfe77c04f6b75a5  brcmfmac43430-sdio.txt
++sha256 beade89c5c072158b6cf18cf741d2695980fd6a4533dab3897bebf90c0631a30  rpi-wifi-firmware-18d7c931aff0a8a78360b9b9eaeb15d1224fb907.tar.gz
++sha256 b16056fc91b82a0e3e8de8f86c2dac98201aa9dc3cbd33e8d38f1b087fcec30d  LICENCE.broadcom_bcm43xx
+diff --git a/package/rpi-wifi-firmware/rpi-wifi-firmware.mk b/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
+index 6c855a8..32dd3e5 100644
+--- a/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
++++ b/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
+@@ -4,20 +4,14 @@
+ #
+ ################################################################################
+ 
+-RPI_WIFI_FIRMWARE_VERSION = 54bab3d6a6d43239c71d26464e6e10e5067ffea7
+-# brcmfmac43430-sdio.bin comes from linux-firmware
+-RPI_WIFI_FIRMWARE_SOURCE = brcmfmac43430-sdio.txt
+-# git repo contains a lot of unrelated files
+-RPI_WIFI_FIRMWARE_SITE = https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/$(RPI_WIFI_FIRMWARE_VERSION)/brcm80211/brcm
++RPI_WIFI_FIRMWARE_VERSION = 18d7c931aff0a8a78360b9b9eaeb15d1224fb907
++RPI_WIFI_FIRMWARE_SITE = $(call github,LibreELEC,brcmfmac_sdio-firmware-rpi,$(RPI_WIFI_FIRMWARE_VERSION))
+ RPI_WIFI_FIRMWARE_LICENSE = PROPRIETARY
+-
+-define RPI_WIFI_FIRMWARE_EXTRACT_CMDS
+-	cp $(DL_DIR)/$($(PKG)_SOURCE) $(@D)/
+-endef
++RPI_WIFI_FIRMWARE_LICENSE_FILES = LICENCE.broadcom_bcm43xx
+ 
+ define RPI_WIFI_FIRMWARE_INSTALL_TARGET_CMDS
+-	$(INSTALL) -D -m 0644 $(@D)/$(RPI_WIFI_FIRMWARE_SOURCE) \
+-		$(TARGET_DIR)/lib/firmware/brcm/$(RPI_WIFI_FIRMWARE_SOURCE)
++	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm
++	$(INSTALL) -m 0644 $(@D)/firmware/brcm/brcmfmac* $(TARGET_DIR)/lib/firmware/brcm
+ endef
+ 
+ $(eval $(generic-package))
+-- 
+2.7.4
+


### PR DESCRIPTION
This pulls in support for the Linux 4.9 kernel on the Raspberry Pi and includes updated firmware files for the Raspberry Pi 3 B+'s WiFi and BT modules.

It also includes a patch to Erlang that I ran into while doing this work.