### PR TITLE
Call readelf directly for executable arch info

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -61,8 +61,8 @@ executable_type()
 {
     READELF_OUTPUT=$("$READELF" -h "$1" 2>&1)
 
-    ELF_MACHINE=$(echo "$READELF_OUTPUT" | sed -r -e '/^  Machine: +(.+)/!d; s//\1/;' | head -1)
-    ELF_FLAGS=$(echo "$READELF_OUTPUT" | sed -r -e '/^  Flags: +(.+)/!d; s//\1/;' | head -1)
+    ELF_MACHINE=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Machine: +(.+)/!d; s//\1/;' | head -1)
+    ELF_FLAGS=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Flags: +(.+)/!d; s//\1/;' | head -1)
 
     if [ -z "$ELF_MACHINE" ]; then
         echo "$SCRIPT_NAME: ERROR: Didn't expect empty machine field in ELF header on $1." 1>&2


### PR DESCRIPTION
We previously used the host system's file command. Depending on the
host, more or less data would be printed out and we'd have to ignore
some of it. This calls the version of readelf that we include in our
toolchains so it should be much more consistent across platforms. It
also verifies less information: only the platform's architecture and any
flags (hard float vs software float/ABI) are checked. This removes the
Linux kernel header check. While the kernel header check is nice, it
currently triggers false errors for Go and Rust-generated binaries.

Fixes #138