### PR TITLE
erlang: bump to 20.3.5

### DIFF
--- a/patches/buildroot/0010-erlang-bump-to-otp-20.3.5.patch
+++ b/patches/buildroot/0010-erlang-bump-to-otp-20.3.5.patch
@@ -1,7 +1,7 @@
-From 06e0b63c3cf5f5ce69bddefe08caf030a8bffaf7 Mon Sep 17 00:00:00 2001
+From ee1f2ae5caeeecd809eda740f7ed61b4801db008 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Fri, 7 Jul 2017 18:23:51 -0400
-Subject: [PATCH] erlang: bump to otp 20.3.4
+Subject: [PATCH] erlang: bump to otp 20.3.5
 
 ---
  package/erlang/0001-build-fix.patch                | 13 ----
@@ -389,7 +389,7 @@ index ad0bb6b..0000000
 -2.14.1
 -
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index cf820ce..22cfbbb 100644
+index cf820ce..9f61f8d 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,3 +1,2 @@
@@ -397,9 +397,9 @@ index cf820ce..22cfbbb 100644
 -md5     2faed2c3519353e6bc2501ed4d8e6ae7        otp_src_20.0.tar.gz
 -sha256  fe80e1e14a2772901be717694bb30ac4e9a07eee0cc7a28988724cbd21476811        otp_src_20.0.tar.gz
 +# sha256 locally computed
-+sha256  6a3b8d42b49dde708ab6faea4bf56b12466d0435e95314f42cedc0471ffcf7ae  OTP-20.3.4.tar.gz
++sha256  da82027fb20db8fe9548cc7020a0227031f049d9b8b687575c41e80461408d78  OTP-20.3.5.tar.gz
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 4b29969..c6245fa 100644
+index 4b29969..de5f686 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,21 +5,18 @@
@@ -410,7 +410,7 @@ index 4b29969..c6245fa 100644
 -ERLANG_SITE = http://www.erlang.org/download
 -ERLANG_SOURCE = otp_src_$(ERLANG_VERSION).tar.gz
 -ERLANG_DEPENDENCIES = host-erlang
-+ERLANG_VERSION = 20.3.4
++ERLANG_VERSION = 20.3.5
 +ERLANG_SITE = https://github.com/erlang/otp/archive
 +ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
 +ERLANG_DEPENDENCIES = host-erlang host-autoconf


### PR DESCRIPTION
Patch Package:           OTP 20.3.5
Git Tag:                 OTP-20.3.5
Date:                    2018-05-03
Trouble Report Id:       OTP-15034, OTP-15050
Seq num:
System:                  OTP
Release:                 20
Application:             erts-9.3.1, ssl-8.2.6
Predecessor:             OTP 20.3.4

 Check out the git tag OTP-20.3.5, and build a full OTP system
 including documentation. Apply one or more applications from this
 build as patches to your installation using the 'otp_patch_apply'
 tool. For information on install requirements, see descriptions for
 each application version below.

 ---------------------------------------------------------------------
 --- erts-9.3.1 ------------------------------------------------------
 ---------------------------------------------------------------------

 The erts-9.3.1 application can be applied independently of other
 applications on a full OTP 20 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-15034    Application(s): erts

               Fixed a crash in heart:get_cmd/0 when the stored
               command was too long.

 Full runtime dependencies of erts-9.3.1: kernel-5.0, sasl-3.0.1,
 stdlib-3.0

 ---------------------------------------------------------------------
 --- ssl-8.2.6 -------------------------------------------------------
 ---------------------------------------------------------------------

 Note! The ssl-8.2.6 application can *not* be applied independently of
       other applications on an arbitrary OTP 20 installation.

       On a full OTP 20 installation, also the following runtime
       dependencies have to be satisfied:
       -- crypto-4.2 (first satisfied in OTP 20.2)
       -- public_key-1.5 (first satisfied in OTP 20.1)

 --- Fixed Bugs and Malfunctions ---

  OTP-15050    Application(s): ssl

               Proper handling of clients that choose to send an empty
               answer to a certificate request

 Full runtime dependencies of ssl-8.2.6: crypto-4.2, erts-7.0,
 inets-5.10.7, kernel-3.0, public_key-1.5, stdlib-3.2

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------