### PR TITLE
boardid: bump to v1.0.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 603b518833592c72d3657093ac61550f4bc91e949cae2b2ca655b319a66bb8e3  boardid-v0.4.0.tar.gz
+sha256 bfba3b30b6731630670c3756b78f2ccd4be930d442de8c06e062703f1b67ac5e  boardid-v1.0.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v0.4.0
+BOARDID_VERSION = v1.0.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This brings in support for reading serial numbers from U-boot
environment variables and letting user specify multiple ways of
generating a unique ID.