### PR TITLE
erlinit: bump to v1.4.1

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 0e14189907e6e2bb71f8cb4fdbe4f9c85e6406eee5929df7e91041eda6f807b6  erlinit-v1.4.0.tar.gz
+sha256 c39a303910651dfd33faf123cb126bf76426aebe44208c605c1ea96d37e2b829  erlinit-v1.4.1.tar.gz

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.0
+ERLINIT_VERSION = v1.4.1
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This adds bulletproofing against whitespace creeping into hostnames.