### PR TITLE
erlang: bump to 20.3.6

### DIFF
--- a/patches/buildroot/0010-erlang-bump-to-otp-20.3.6.patch
+++ b/patches/buildroot/0010-erlang-bump-to-otp-20.3.6.patch
@@ -1,7 +1,7 @@
-From ee1f2ae5caeeecd809eda740f7ed61b4801db008 Mon Sep 17 00:00:00 2001
+From e25949afa0e832e4553210529db685f65fe21da9 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Fri, 7 Jul 2017 18:23:51 -0400
-Subject: [PATCH] erlang: bump to otp 20.3.5
+Subject: [PATCH] erlang: bump to otp 20.3.6
 
 ---
  package/erlang/0001-build-fix.patch                | 13 ----
@@ -389,7 +389,7 @@ index ad0bb6b..0000000
 -2.14.1
 -
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index cf820ce..9f61f8d 100644
+index cf820ce..5c7b7be 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,3 +1,2 @@
@@ -397,9 +397,9 @@ index cf820ce..9f61f8d 100644
 -md5     2faed2c3519353e6bc2501ed4d8e6ae7        otp_src_20.0.tar.gz
 -sha256  fe80e1e14a2772901be717694bb30ac4e9a07eee0cc7a28988724cbd21476811        otp_src_20.0.tar.gz
 +# sha256 locally computed
-+sha256  da82027fb20db8fe9548cc7020a0227031f049d9b8b687575c41e80461408d78  OTP-20.3.5.tar.gz
++sha256  2494df496943387dbdb895a8b6cf8c04807f6888ae1f7dab25290ad89dcf0eb2  OTP-20.3.6.tar.gz
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 4b29969..de5f686 100644
+index 4b29969..f60839d 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,21 +5,18 @@
@@ -410,7 +410,7 @@ index 4b29969..de5f686 100644
 -ERLANG_SITE = http://www.erlang.org/download
 -ERLANG_SOURCE = otp_src_$(ERLANG_VERSION).tar.gz
 -ERLANG_DEPENDENCIES = host-erlang
-+ERLANG_VERSION = 20.3.5
++ERLANG_VERSION = 20.3.6
 +ERLANG_SITE = https://github.com/erlang/otp/archive
 +ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
 +ERLANG_DEPENDENCIES = host-erlang host-autoconf


### PR DESCRIPTION
Patch Package:           OTP 20.3.6
Git Tag:                 OTP-20.3.6
Date:                    2018-05-08
Trouble Report Id:       OTP-15064, OTP-15066, OTP-15073, OTP-15074
Seq num:                 ERL-618
System:                  OTP
Release:                 20
Application:             crypto-4.2.2, ssh-4.6.9
Predecessor:             OTP 20.3.5

Check out the git tag OTP-20.3.6, and build a full OTP system
including documentation. Apply one or more applications from this
build as patches to your installation using the 'otp_patch_apply'
tool. For information on install requirements, see descriptions for
each application version below.

---------------------------------------------------------------------
--- crypto-4.2.2 ----------------------------------------------------
---------------------------------------------------------------------

The crypto-4.2.2 application can be applied independently of other
applications on a full OTP 20 installation.

--- Fixed Bugs and Malfunctions ---

 OTP-15073    Application(s): crypto

              If OPENSSL_NO_EC was set, the compilation of the crypto
              nifs failed.

 OTP-15074    Application(s): crypto
              Related Id(s): ERL-618

              C-compile errors for LibreSSL 2.7.0 - 2.7.2 fixed

Full runtime dependencies of crypto-4.2.2: erts-9.0, kernel-5.3,
stdlib-3.4

---------------------------------------------------------------------
--- ssh-4.6.9 -------------------------------------------------------
---------------------------------------------------------------------

Note! The ssh-4.6.9 application can *not* be applied independently of
      other applications on an arbitrary OTP 20 installation.

      On a full OTP 20 installation, also the following runtime
      dependencies have to be satisfied:
      -- crypto-4.2 (first satisfied in OTP 20.2)
      -- public_key-1.5.2 (first satisfied in OTP 20.2)

--- Fixed Bugs and Malfunctions ---

 OTP-15064    Application(s): ssh

              Host key hash erroneously calculated for clients
              following draft-00 of RFC 4419, for example PuTTY

 OTP-15066    Application(s): ssh

              Renegotiation could fail in some states

Full runtime dependencies of ssh-4.6.9: crypto-4.2, erts-6.0,
kernel-3.0, public_key-1.5.2, stdlib-3.3