### PR TITLE
Dockerfile: bump OTP to 20.3 and fwup to 1.1.0

### DIFF
--- a/support/docker/nerves/Dockerfile
+++ b/support/docker/nerves/Dockerfile
@@ -5,10 +5,10 @@ description="Container with everything needed to build Nerves projects"
 
 # Setup environment
 ENV DEBIAN_FRONTEND noninteractive
-ENV LANG=C.UTF-8 
-ENV TERM=xterm 
-ENV ERLANG_OTP_VERSION=20.2.2
-ENV FWUP_VERSION=1.0.0
+ENV LANG=C.UTF-8
+ENV TERM=xterm
+ENV ERLANG_OTP_VERSION=20.3
+ENV FWUP_VERSION=1.1.0
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"
 # The container has no package lists, so need to update first


### PR DESCRIPTION
I didn't test this, but I assume that it would be good to keep the versions in this file up-to-date?