### PR TITLE
boardid: bump to v1.1.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 bfba3b30b6731630670c3756b78f2ccd4be930d442de8c06e062703f1b67ac5e  boardid-v1.0.0.tar.gz
+sha256 a6a787f32eb0928869d3a9dcbcc5fb06d9c9cfd0728ba64efe175fd675308899  boardid-v1.1.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.0.0
+BOARDID_VERSION = v1.1.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This removes the need for every system to duplicate its U-boot
environment parameters in erlinit.config. In other words, boardid reads
/etc/fw_env.config now.