### PR TITLE
boardid: bump to v1.1.1

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 a6a787f32eb0928869d3a9dcbcc5fb06d9c9cfd0728ba64efe175fd675308899  boardid-v1.1.0.tar.gz
+sha256 cef56a669b9483109768ab194576fd9c038044dee6280e4797f63cdfb3b0439b  boardid-v1.1.1.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.1.0
+BOARDID_VERSION = v1.1.1
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This addresses an issue with using empty U-Boot environment variables.
An empty `serial_number` won't be used to supply a board's ID.