### PR TITLE
fwup: bump to v1.2.1

### DIFF
--- a/patches/buildroot/0009-fwup-bump-to-v1.2.1.patch
+++ b/patches/buildroot/0009-fwup-bump-to-v1.2.1.patch
@@ -1,7 +1,7 @@
-From ed029e7982d73a908733c4a17becc6353224cd56 Mon Sep 17 00:00:00 2001
+From d3395409aadc5760c9bb7b5c42c636657f079ff5 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Sun, 25 Jun 2017 22:32:02 -0400
-Subject: [PATCH] fwup: bump to v1.2.0
+Subject: [PATCH] fwup: bump to v1.2.1
 
 ---
  package/fwup/fwup.hash | 2 +-
@@ -9,15 +9,15 @@ Subject: [PATCH] fwup: bump to v1.2.0
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
-index 32398bf..b083b2b 100644
+index 32398bf..34ef281 100644
 --- a/package/fwup/fwup.hash
 +++ b/package/fwup/fwup.hash
 @@ -1,2 +1,2 @@
  # Locally calculated
 -sha256 852e255bd65f9db473a06184abb3e94e3b6b86be7bf66169e8df8146d5966ae1  fwup-v0.15.4.tar.gz
-+sha256 e20b22b01e921102e61daea2e5fafd80ce2c5ee868e19f756dccf33f2a6bd61a  fwup-v1.2.0.tar.gz
++sha256 054af579574049f4c64307320808d6900323dbca80edfc042ba98ee198602b53  fwup-v1.2.1.tar.gz
 diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
-index c6a18c2..b3e75ec 100644
+index c6a18c2..88383b7 100644
 --- a/package/fwup/fwup.mk
 +++ b/package/fwup/fwup.mk
 @@ -4,7 +4,7 @@
@@ -25,7 +25,7 @@ index c6a18c2..b3e75ec 100644
  ################################################################################
  
 -FWUP_VERSION = v0.15.4
-+FWUP_VERSION = v1.2.0
++FWUP_VERSION = v1.2.1
  FWUP_SITE = $(call github,fhunleth,fwup,$(FWUP_VERSION))
  FWUP_LICENSE = Apache-2.0
  FWUP_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This version adds some bulletproofing and additional regression tests to
meta-uuid. It also adds support for ${FWUP_META_UUID} so that the UUID
can be referenced in fwup.conf scripts. This is needed to support saving
the UUID to the Nerves.Runtime.KV metadata so that it can be accessed by
firmware update libraries.