### PR TITLE
erlinit: bump to v1.4.2

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 c39a303910651dfd33faf123cb126bf76426aebe44208c605c1ea96d37e2b829  erlinit-v1.4.1.tar.gz
+sha256 8ace0f22b5ba9634e936e321d0d8fe3b04b0fbb8af52893f70c68003c49f7c31  erlinit-v1.4.2.tar.gz

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.1
+ERLINIT_VERSION = v1.4.2
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This pulls in an update to the filesystem mount calls that fixes
a parse error from Docker.