### PR TITLE
nbtty: bump to v0.4.0

### DIFF
--- a/package/nbtty/nbtty.hash
+++ b/package/nbtty/nbtty.hash
@@ -1,2 +1,2 @@
 # Locally computed:
-sha256  56d8be9069fc8745b6ef1886516d382079a9057962041626e46dfb95160c2f02  nbtty-v0.3.2.tar.gz
+sha256  f409f0375b14eebe1d43e554027abd78cffab441190df3eaa2f6ad004e971c0b  nbtty-v0.4.0.tar.gz

--- a/package/nbtty/nbtty.mk
+++ b/package/nbtty/nbtty.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-NBTTY_VERSION = v0.3.2
+NBTTY_VERSION = v0.4.0
 NBTTY_SITE = $(call github,fhunleth,nbtty,$(NBTTY_VERSION))
 NBTTY_LICENSE = GPL-2.0+
 NBTTY_LICENSE_FILES = COPYING


### PR DESCRIPTION
This pulls in a fix for process exits not being detected and support for
retrying tty files so that progress can be made on configfs/USB gadget
work.