### PR TITLE
erlinit: bump to v1.4.4

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 6b12a09b1d3a133a3bf4f2b7e657ef7d2886b7c2894e863f88186e75f268d68b  erlinit-v1.4.3.tar.gz
+sha256 0a86152880b6a9f91e48523a78a8d4b39407fdf5ce0b96cc5f41e7969ef9f7b9  erlinit-v1.4.4.tar.gz

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.3
+ERLINIT_VERSION = v1.4.4
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This pulls in the signal mask fix. This fixes an issue where nbtty was
waiting for SIGCHLD, but would not receive it since it inherited
erlinit's signal mask. The signal mask is restored to the default before
launching applications now so that applications don't need to force
their signal masks.