### PR TITLE
Add rng-tools to all Nerves systems

### DIFF
--- a/package/nerves-config/Config.in
+++ b/package/nerves-config/Config.in
@@ -10,6 +10,7 @@ menuconfig BR2_PACKAGE_NERVES_CONFIG
 	select BR2_PACKAGE_BOARDID  # ID board for assigning unique names
 	select BR2_PACKAGE_HOST_FWUP # Used by Nerves packaging tools
 	select BR2_TARGET_ROOTFS_SQUASHFS # Nerves uses squashfs archives
+	select BR2_PACKAGE_RNG_TOOLS # rngd needed for cryptographic random number gen
 	help
 	  Nerves system configuration helper. This selects a set of packages
 	  used by all Nerves systems so that they're never accidentally omitted.

--- a/package/nerves-config/nerves-config.mk
+++ b/package/nerves-config/nerves-config.mk
@@ -9,7 +9,7 @@
 NERVES_CONFIG_SOURCE =
 NERVES_CONFIG_VERSION = 0.7
 
-NERVES_CONFIG_DEPENDENCIES = erlinit erlang host-fwup fwup ncurses nerves_heart uboot-tools boardid openssl
+NERVES_CONFIG_DEPENDENCIES = erlinit erlang host-fwup fwup ncurses nerves_heart uboot-tools boardid openssl rng-tools
 
 # This is tricky. We want the squashfs created by Buildroot to have everything
 # except for the OTP release. The squashfs tools can only append to


### PR DESCRIPTION
This change makes rng-tools a require dependency for all Nerves systems
and results in two ~16 KB binaries being installed. One is `rngd` and
the other is `rngtest`.

The `rngd` program transfers random data from hardware generators to the
Linux kernel. This is very important since the getrandom() syscall can
hang programs for 5 minutes at boot while the kernel accumulates
entropy. The hardware random number generators can get the kernel going
very quickly.

This issue has become more prevalent due to C libraries, the Linux
kernel and applications getting better with how they gather their
cryptographic random data and using cryptographic random number for more
things.