### PR TITLE
Print the gcc version

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -71,11 +71,12 @@ else
     # Found it. Print out some useful information so that the user can
     # easily figure out whether the wrong nerves installation was used.
     NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= $NERVES_SYSTEM/.config | sed -e 's/BR2_DEFCONFIG="\(.*\)"/\1/')
+    GCC_VERSION=$($CROSSCOMPILE-gcc --version | head -1)
 
     echo "Shell environment updated for Nerves"
     echo
     echo "Nerves configuration: $NERVES_DEFCONFIG"
-    echo "Cross-compiler prefix: $(basename $CROSSCOMPILE)"
+    echo "Cross-compiler: $GCC_VERSION"
     echo "Erlang/OTP release on target: $NERVES_TARGET_ERL_VER"
     if [ -n "$(which elixir)" ]; then
         NERVES_ELIXIR_VERSION=$(elixir -v | grep lixir | cut -d' ' -f2-)


### PR DESCRIPTION
This is more useful than just printing the crosscompiler prefix for
those of us who use this script.