### PR TITLE
Support Qt/QMake projects

### DIFF
--- a/nerves_env.exs
+++ b/nerves_env.exs
@@ -135,6 +135,13 @@ System.put_env("LDFLAGS", "--sysroot=#{sdk_sysroot}")
 System.put_env("ERL_CFLAGS", "-I#{erts_dir}/include -I#{erl_interface_dir}/include")
 System.put_env("ERL_LDFLAGS", "-L#{erts_dir}/lib -L#{erl_interface_dir}/lib -lerts -lerl_interface -lei")
 
+# Qt/Qmake support
+qmakespec_dir =
+  Path.join(system_path, "staging/mkspecs")
+if File.dir?(qmakespec_dir) do
+  System.put_env("QMAKESPEC", qmakespec_dir)
+end
+
 # Rebar naming
 System.put_env("REBAR_TARGET_ARCH", Path.basename(crosscompile))
 System.put_env("ERL_EI_LIBDIR", Path.join(erl_interface_dir, "lib"))

--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -115,6 +115,11 @@ export ERL_CFLAGS="-I$ERTS_DIR/include -I$ERL_INTERFACE_DIR/include"
 export ERL_LDFLAGS="-L$ERTS_DIR/lib -L$ERL_INTERFACE_DIR/lib -lerts -lerl_interface -lei"
 export REBAR_TARGET_ARCH=$(basename $CROSSCOMPILE)
 
+# Qt/QMake
+if [ -e "$NERVES_SDK_SYSROOT/mkspecs/devices/linux-buildroot-g++" ]; then
+    export QMAKESPEC=$NERVES_SDK_SYSROOT/mkspecs/devices/linux-buildroot-g++
+fi
+
 # Rebar naming
 export ERL_EI_LIBDIR="$ERL_INTERFACE_DIR/lib"
 export ERL_EI_INCLUDE_DIR="$ERL_INTERFACE_DIR/include"


### PR DESCRIPTION
This saves the mkspecs directory to staging so that it gets distributed
with systems and then sets the QMAKESPECS environment variable for
builds. `qmake` will look at the variable to know how to build Qt-based
projects.