### PR TITLE
Create and switch user in docker entrypoint if one was set

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -13,6 +13,9 @@ ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+COPY docker-entrypoint.sh /nerves/docker-entrypoint.sh
+RUN chmod +x /nerves/docker-entrypoint.sh
+
 # Set time
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
@@ -83,3 +86,5 @@ RUN dpkg --add-architecture i386 \
   && apt-get -q -y autoremove \
   && apt-get -q -y clean \
   && mkdir -p /nerves/build && chmod 777 /nerves/build
+
+ENTRYPOINT [ "/nerves/docker-entrypoint.sh" ]

--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0" ]]; then
+  echo "Setting User"
+  echo "UID: $UID"
+  echo "GID: $GID"
+
+  useradd -g $GID -u $UID -m nerves
+  echo "Switching user"
+  su nerves
+fi
+
+exec "$@"


### PR DESCRIPTION
When running the docker image, we set the user and group ids to those of the user from the host. This fixes permissions issues that arise from writing files back to the host from within the container. Unfortunately since this user and group do not actually exist, it can cause some bad behavior with packages in buildroot. In the example case, `host-ncurses`. This will set the entrypoint and create and switch users if the values were passed through in the `--env`