### PR TITLE
erlang: bump to 21.0.5

### DIFF
--- a/patches/buildroot/0009-erlang-bump-to-21.0.patch
+++ b/patches/buildroot/0009-erlang-bump-to-21.0.patch
@@ -1,4 +1,4 @@
-From 6b6655e0f529b363a9c56695b9ea1efe0be54cba Mon Sep 17 00:00:00 2001
+From e561c3649bbd2b1dffc740499ff468f9433e8749 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Fri, 7 Jul 2017 18:23:51 -0400
 Subject: [PATCH] erlang: bump to 21.0
@@ -159,7 +159,7 @@ index ad0bb6b453..391b6ebac2 100644
 +2.7.4
  
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index f5ff74022c..e5efbf821b 100644
+index f5ff74022c..e453d667f9 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,2 @@
@@ -168,9 +168,9 @@ index f5ff74022c..e5efbf821b 100644
 -sha256 4e19e6c403d5255531c0b870f19511c8b8e3b080618e4f9efcb44d905935b2a1  otp_src_20.3.tar.gz
 -sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 +# sha256 locally computed
-+sha256  8830c81042835070d72130a0df78058a5ccb8db9f93829310d93ed6e2e323e0d  OTP-21.0.4.tar.gz
++sha256  70124f91693364f7fd2ec65baa45c434f069a14f5aa2c18377e1c3f320f47ac5  OTP-21.0.5.tar.gz
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index b992d1c6c6..904f6358ef 100644
+index b992d1c6c6..4c565513c0 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,21 +5,18 @@
@@ -181,7 +181,7 @@ index b992d1c6c6..904f6358ef 100644
 -ERLANG_SITE = http://www.erlang.org/download
 -ERLANG_SOURCE = otp_src_$(ERLANG_VERSION).tar.gz
 -ERLANG_DEPENDENCIES = host-erlang
-+ERLANG_VERSION = 21.0.4
++ERLANG_VERSION = 21.0.5
 +ERLANG_SITE = https://github.com/erlang/otp/archive
 +ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
 +ERLANG_DEPENDENCIES = host-erlang host-autoconf


### PR DESCRIPTION
 ---------------------------------------------------------------------
  --- POTENTIAL INCOMPATIBILITIES -------------------------------------
  ---------------------------------------------------------------------

   OTP-15225    Application(s): erts

                Fixed a bug causing some Erlang references to be
                inconsistently ordered. This could for example cause
                failure to look up certain elements with references as
                keys in search data structures. This bug was introduced
                in R13B02.

                Thanks to Simon Cornish for finding the bug and
                supplying a fix.

  ---------------------------------------------------------------------
  --- compiler-7.2.3 --------------------------------------------------
  ---------------------------------------------------------------------

  The compiler-7.2.3 application can be applied independently of other
  applications on a full OTP 21 installation.

  --- Fixed Bugs and Malfunctions ---

   OTP-15204    Application(s): compiler
                Related Id(s): ERL-679

                Fixed an issue where files compiled with the
                +deterministic option differed if they were compiled in
                a different directory but were otherwise identical.

  Full runtime dependencies of compiler-7.2.3: crypto-3.6, erts-9.0,
  hipe-3.12, kernel-4.0, stdlib-2.5

  ---------------------------------------------------------------------
  --- crypto-4.3.1 ----------------------------------------------------
  ---------------------------------------------------------------------

  The crypto-4.3.1 application can be applied independently of other
  applications on a full OTP 21 installation.

  --- Fixed Bugs and Malfunctions ---

   OTP-15194    Application(s): crypto
                Related Id(s): ERL-673

                Fixed a node crash in crypto:compute_key(ecdh, ...)
                when passing a wrongly typed Others argument.

  Full runtime dependencies of crypto-4.3.1: erts-9.0, kernel-5.3,
  stdlib-3.4

  ---------------------------------------------------------------------
  --- erts-10.0.5 -----------------------------------------------------
  ---------------------------------------------------------------------

  The erts-10.0.5 application can be applied independently of other
  applications on a full OTP 21 installation.

  --- Fixed Bugs and Malfunctions ---

   OTP-15223    Application(s): erts

                Fixed a bug which caused an emulator crash when
                enif_send() was called by a NIF that executed on a
                dirty scheduler. The bug was either triggered when the
                NIF called enif_send() without a message environment,
                or when the process executing the NIF was send traced.

   OTP-15225    Application(s): erts

                *** POTENTIAL INCOMPATIBILITY ***

                Fixed a bug causing some Erlang references to be
                inconsistently ordered. This could for example cause
                failure to look up certain elements with references as
                keys in search data structures. This bug was introduced
                in R13B02.

                Thanks to Simon Cornish for finding the bug and
                supplying a fix.

  Full runtime dependencies of erts-10.0.5: kernel-6.0, sasl-3.0.1,
  stdlib-3.5