### PR TITLE
erlang: continue to support OTP 20 systems

### DIFF
--- a/patches/buildroot/0015-erlang-make-OTP-version-configurable.patch
+++ b/patches/buildroot/0015-erlang-make-OTP-version-configurable.patch
@@ -1,0 +1,634 @@
+From c452b3bd7a8c23a438922e074cab52251354635b Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Mon, 13 Aug 2018 21:49:55 -0400
+Subject: [PATCH] erlang: make OTP version configurable
+
+This makes it possible to build either OTP 20 or OTP 21-based Nerves
+systems.
+---
+ ...truct-libatomic_ops-we-do-require-CA.patch | 71 -------------------
+ ...ulator-reorder-inclued-headers-paths.patch | 47 ------------
+ ...-with-LDLIBS-instead-of-LIBS-for-DED.patch | 42 -----------
+ ...truct-libatomic_ops-we-do-require-CA.patch | 70 ++++++++++++++++++
+ ...ulator-reorder-inclued-headers-paths.patch | 43 +++++++++++
+ ...-with-LDLIBS-instead-of-LIBS-for-DED.patch | 42 +++++++++++
+ ...truct-libatomic_ops-we-do-require-CA.patch | 71 +++++++++++++++++++
+ ...ulator-reorder-inclued-headers-paths.patch | 47 ++++++++++++
+ ...-with-LDLIBS-instead-of-LIBS-for-DED.patch | 42 +++++++++++
+ package/erlang/Config.in                      | 18 +++++
+ package/erlang/erlang.hash                    |  1 +
+ package/erlang/erlang.mk                      | 12 ++++
+ 12 files changed, 346 insertions(+), 160 deletions(-)
+ delete mode 100644 package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ delete mode 100644 package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ delete mode 100644 package/erlang/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+ create mode 100644 package/erlang/20.3.8.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/20.3.8.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/20.3.8.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+ create mode 100644 package/erlang/21.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/21.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/21.0.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+
+diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+deleted file mode 100644
+index ccb1e8432f..0000000000
+--- a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ /dev/null
+@@ -1,71 +0,0 @@
+-From f6217a2d195359a1956c20d2600b59d61be8f848 Mon Sep 17 00:00:00 2001
+-From: "Yann E. MORIN" <yann.morin.1998@free.fr>
+-Date: Sun, 28 Dec 2014 23:39:40 +0100
+-Subject: [PATCH] erts/ethread: instruct libatomic_ops we do require CAS
+-
+-We do require compare-and-swap (CAS), so we must instruct libatomic_ops
+-to provide it, even if the architecture does not have instructions for
+-it.
+-
+-For example, on ARM, LDREX is required for fast CAS. But LDREX is only
+-available on ARMv6, so by default libatomic_ops will not have CAS for
+-anything below, like ARMv5. But ARMv5 is always UP, so using an
+-emulated CAS (that is signal-asyn-safe) is still possible (albeit much
+-slower).
+-
+-Tell libatomic_ops to provide CAS, even if the hardware is not capable
+-of it, by using emulated CAS, as per libatomic_ops dosc:
+-    https://github.com/ivmai/libatomic_ops/blob/master/doc/README.txt#L28
+-
+-    If this is included after defining AO_REQUIRE_CAS, then the package
+-    will make an attempt to emulate compare-and-swap in a way that (at
+-    least on Linux) should still be async-signal-safe.
+-
+-Thanks go to Thomas for all this insight! :-)
+-Thanks go to Frank for reporting the issue! :-)
+-
+-Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+-Cc: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+-Cc: Frank Hunleth <fhunleth@troodon-software.com>
+----
+- erts/aclocal.m4                               | 4 +++-
+- erts/include/internal/libatomic_ops/ethread.h | 1 +
+- 2 files changed, 4 insertions(+), 1 deletion(-)
+-
+-diff --git a/erts/aclocal.m4 b/erts/aclocal.m4
+-index 80bf236..56d9dee 100644
+---- a/erts/aclocal.m4
+-+++ b/erts/aclocal.m4
+-@@ -1973,7 +1973,8 @@ case "$THR_LIB_NAME" in
+- 	    	    fi;;
+- 	    esac
+- 	    ethr_have_libatomic_ops=no
+--	    AC_TRY_LINK([#include "atomic_ops.h"],
+-+	    AC_TRY_LINK([#define AO_REQUIRE_CAS
+-+                    #include "atomic_ops.h"],
+- 	    	        [
+- 	    	    	    volatile AO_t x;
+- 	    	    	    AO_t y;
+-@@ -2014,6 +2015,7 @@ case "$THR_LIB_NAME" in
+- 	        AC_CHECK_SIZEOF(AO_t, ,
+- 	    	    	        [
+- 	    	    	    	    #include <stdio.h>
+-+	    	    	    	    #define AO_REQUIRE_CAS
+- 	    	    	    	    #include "atomic_ops.h"
+- 	    	    	        ])
+- 	        AC_DEFINE_UNQUOTED(ETHR_SIZEOF_AO_T, $ac_cv_sizeof_AO_t, [Define to the size of AO_t if libatomic_ops is used])
+-diff --git a/erts/include/internal/libatomic_ops/ethread.h b/erts/include/internal/libatomic_ops/ethread.h
+-index 4adc31e..18cc22a 100644
+---- a/erts/include/internal/libatomic_ops/ethread.h
+-+++ b/erts/include/internal/libatomic_ops/ethread.h
+-@@ -36,6 +36,7 @@
+- 
+- #define ETHR_NATIVE_IMPL__ "libatomic_ops"
+- 
+-+#define AO_REQUIRE_CAS
+- #include "atomic_ops.h"
+- #include "ethr_membar.h"
+- #include "ethr_atomic.h"
+--- 
+-2.7.4
+-
+diff --git a/package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch
+deleted file mode 100644
+index a2cecfbad2..0000000000
+--- a/package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ /dev/null
+@@ -1,47 +0,0 @@
+-From 09b88921b947836834b62da41b18212cb92dc076 Mon Sep 17 00:00:00 2001
+-From: Romain Naour <romain.naour@openwide.fr>
+-Date: Sun, 8 Feb 2015 17:23:13 +0100
+-Subject: [PATCH] erts/emulator: reorder inclued headers paths
+-
+-If the Perl Compatible Regular Expressions is installed on the
+-host and the path to the headers is added to the CFLAGS, the
+-pcre.h from the host is used instead of the one provided by
+-erlang.
+-
+-Erlang use an old version of this file which is incompatible
+-with the upstream one.
+-
+-Move INCLUDES before CFLAGS to use pcre.h from erlang.
+-
+-http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
+-
+-Signed-off-by: Romain Naour <romain.naour@openwide.fr>
+----
+- erts/emulator/Makefile.in | 4 ++--
+- 1 file changed, 2 insertions(+), 2 deletions(-)
+-
+-diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
+-index 0546928..38c2f05 100644
+---- a/erts/emulator/Makefile.in
+-+++ b/erts/emulator/Makefile.in
+-@@ -712,7 +712,7 @@ endif
+- # Usually the same as the default rule, but certain platforms (e.g. win32) mix
+- # different compilers
+- $(OBJDIR)/beam_emu.o: beam/beam_emu.c
+--	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+-+	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+- 
+- $(OBJDIR)/beam_emu.S: beam/beam_emu.c
+- 	$(V_EMU_CC) -S -fverbose-asm $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+-@@ -765,7 +765,7 @@ endif
+- # General targets
+- #
+- $(OBJDIR)/%.o: beam/%.c
+--	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+-+	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
+- 
+- $(OBJDIR)/%.o: $(TARGET)/%.c
+- 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@
+--- 
+-2.7.4
+-
+diff --git a/package/erlang/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch b/package/erlang/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+deleted file mode 100644
+index 391b6ebac2..0000000000
+--- a/package/erlang/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
++++ /dev/null
+@@ -1,42 +0,0 @@
+-From 7baac8804d9441c1bc5db1115eccd290c8b99eda Mon Sep 17 00:00:00 2001
+-From: Johan Oudinet <johan.oudinet@gmail.com>
+-Date: Wed, 6 Dec 2017 15:01:17 +0100
+-Subject: [PATCH] Link with LDLIBS instead of LIBS for DED
+-
+-Fix ERL-529 by avoiding to link with libz for no reason.
+-
+-Signed-off-by: Johan Oudinet <johan.oudinet@gmail.com>
+----
+- lib/asn1/c_src/Makefile             | 2 +-
+- lib/runtime_tools/c_src/Makefile.in | 2 +-
+- 2 files changed, 2 insertions(+), 2 deletions(-)
+-
+-diff --git a/lib/asn1/c_src/Makefile b/lib/asn1/c_src/Makefile
+-index 1f714df..f7c6b8b 100644
+---- a/lib/asn1/c_src/Makefile
+-+++ b/lib/asn1/c_src/Makefile
+-@@ -126,7 +126,7 @@ $(NIF_LIB_FILE): $(NIF_STATIC_OBJ_FILES)
+- 	$(V_RANLIB) $@
+- 
+- $(NIF_SHARED_OBJ_FILE): $(NIF_OBJ_FILES)
+--	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LIBS)
+-+	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LDLIBS)
+- 
+- # ----------------------------------------------------
+- # Release Target
+-diff --git a/lib/runtime_tools/c_src/Makefile.in b/lib/runtime_tools/c_src/Makefile.in
+-index 4530a83..4e13e0d 100644
+---- a/lib/runtime_tools/c_src/Makefile.in
+-+++ b/lib/runtime_tools/c_src/Makefile.in
+-@@ -95,7 +95,7 @@ $(OBJDIR)/%$(TYPEMARKER).o: %.c dyntrace_lttng.h
+- 	$(V_CC) -c -o $@ $(ALL_CFLAGS) $<
+- 
+- $(LIBDIR)/%$(TYPEMARKER).@DED_EXT@: $(OBJDIR)/%$(TYPEMARKER).o
+--	$(V_LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+-+	$(V_LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+- 
+- clean:
+- 	rm -f $(TRACE_LIBS)
+--- 
+-2.7.4
+-
+diff --git a/package/erlang/20.3.8.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/20.3.8.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+new file mode 100644
+index 0000000000..8e401430fe
+--- /dev/null
++++ b/package/erlang/20.3.8.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+@@ -0,0 +1,70 @@
++From 439fa2eae78a8900bda120072335be19d626498c Mon Sep 17 00:00:00 2001
++From: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Date: Sun, 28 Dec 2014 23:39:40 +0100
++Subject: [PATCH] erts/ethread: instruct libatomic_ops we do require CAS
++
++We do require compare-and-swap (CAS), so we must instruct libatomic_ops
++to provide it, even if the architecture does not have instructions for
++it.
++
++For example, on ARM, LDREX is required for fast CAS. But LDREX is only
++available on ARMv6, so by default libatomic_ops will not have CAS for
++anything below, like ARMv5. But ARMv5 is always UP, so using an
++emulated CAS (that is signal-asyn-safe) is still possible (albeit much
++slower).
++
++Tell libatomic_ops to provide CAS, even if the hardware is not capable
++of it, by using emulated CAS, as per libatomic_ops dosc:
++    https://github.com/ivmai/libatomic_ops/blob/master/doc/README.txt#L28
++
++    If this is included after defining AO_REQUIRE_CAS, then the package
++    will make an attempt to emulate compare-and-swap in a way that (at
++    least on Linux) should still be async-signal-safe.
++
++Thanks go to Thomas for all this insight! :-)
++Thanks go to Frank for reporting the issue! :-)
++
++Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Cc: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Cc: Frank Hunleth <fhunleth@troodon-software.com>
++---
++ erts/include/internal/libatomic_ops/ethread.h | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/erts/include/internal/libatomic_ops/ethread.h b/erts/include/internal/libatomic_ops/ethread.h
++index d65ee19..71d3598 100644
++--- a/erts/include/internal/libatomic_ops/ethread.h
+++++ b/erts/include/internal/libatomic_ops/ethread.h
++@@ -35,6 +35,7 @@
++ 
++ #define ETHR_NATIVE_IMPL__ "libatomic_ops"
++ 
+++#define AO_REQUIRE_CAS
++ #include "atomic_ops.h"
++ #include "ethr_membar.h"
++ #include "ethr_atomic.h"
++diff --git a/erts/aclocal.m4 b/erts/aclocal.m4
++index d65ee19..71d3598 100644
++--- a/erts/aclocal.m4
+++++ b/erts/aclocal.m4
++@@ -1414,7 +1414,8 @@
++ 	    	    fi;;
++ 	    esac
++ 	    ethr_have_libatomic_ops=no
++-	    AC_TRY_LINK([#include "atomic_ops.h"],
+++	    AC_TRY_LINK([#define AO_REQUIRE_CAS
+++                    #include "atomic_ops.h"],
++ 	    	        [
++ 	    	    	    volatile AO_t x;
++ 	    	    	    AO_t y;
++@@ -1455,6 +1455,7 @@
++ 	        AC_CHECK_SIZEOF(AO_t, ,
++ 	    	    	        [
++ 	    	    	    	    #include <stdio.h>
+++	    	    	    	    #define AO_REQUIRE_CAS
++ 	    	    	    	    #include "atomic_ops.h"
++ 	    	    	        ])
++ 	        AC_DEFINE_UNQUOTED(ETHR_SIZEOF_AO_T, $ac_cv_sizeof_AO_t, [Define to the size of AO_t if libatomic_ops is used])
++-- 
++1.9.1
++
+diff --git a/package/erlang/20.3.8.5/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/20.3.8.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+new file mode 100644
+index 0000000000..c17eefc2a1
+--- /dev/null
++++ b/package/erlang/20.3.8.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+@@ -0,0 +1,43 @@
++From 85a3e5b4f65e5284e59dcdd90e92ea7d50ef6907 Mon Sep 17 00:00:00 2001
++From: Romain Naour <romain.naour@openwide.fr>
++Date: Sun, 8 Feb 2015 17:23:13 +0100
++Subject: [PATCH] erts/emulator: reorder inclued headers paths
++
++If the Perl Compatible Regular Expressions is installed on the
++host and the path to the headers is added to the CFLAGS, the
++pcre.h from the host is used instead of the one provided by
++erlang.
++
++Erlang use an old version of this file which is incompatible
++with the upstream one.
++
++Move INCLUDES before CFLAGS to use pcre.h from erlang.
++
++http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
++
++Signed-off-by: Romain Naour <romain.naour@openwide.fr>
++---
++ erts/emulator/Makefile.in | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
++index 7145824..d079487 100644
++--- a/erts/emulator/Makefile.in
+++++ b/erts/emulator/Makefile.in
++@@ -678,11 +678,11 @@ else
++ # Usually the same as the default rule, but certain platforms (e.g. win32) mix
++ # different compilers
++ $(OBJDIR)/beam_emu.o: beam/beam_emu.c
++-	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ endif
++ 
++ $(OBJDIR)/%.o: beam/%.c
++-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ 
++ $(OBJDIR)/%.o: $(TARGET)/%.c
++ 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@
++-- 
++1.9.3
++
+diff --git a/package/erlang/20.3.8.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch b/package/erlang/20.3.8.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+new file mode 100644
+index 0000000000..ad0bb6b453
+--- /dev/null
++++ b/package/erlang/20.3.8.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+@@ -0,0 +1,42 @@
++From 011752ec7b31e3dde376270fc65c7ee70644f6e7 Mon Sep 17 00:00:00 2001
++From: Johan Oudinet <johan.oudinet@gmail.com>
++Date: Wed, 6 Dec 2017 15:01:17 +0100
++Subject: [PATCH] Link with LDLIBS instead of LIBS for DED
++
++Fix ERL-529 by avoiding to link with libz for no reason.
++
++Signed-off-by: Johan Oudinet <johan.oudinet@gmail.com>
++---
++ lib/asn1/c_src/Makefile             | 2 +-
++ lib/runtime_tools/c_src/Makefile.in | 2 +-
++ 2 files changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/lib/asn1/c_src/Makefile b/lib/asn1/c_src/Makefile
++index 1f714df357..f7c6b8b9bc 100644
++--- a/lib/asn1/c_src/Makefile
+++++ b/lib/asn1/c_src/Makefile
++@@ -126,7 +126,7 @@ $(NIF_LIB_FILE): $(NIF_STATIC_OBJ_FILES)
++ 	$(V_RANLIB) $@
++ 
++ $(NIF_SHARED_OBJ_FILE): $(NIF_OBJ_FILES)
++-	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LIBS)
+++	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LDLIBS)
++ 
++ # ----------------------------------------------------
++ # Release Target
++diff --git a/lib/runtime_tools/c_src/Makefile.in b/lib/runtime_tools/c_src/Makefile.in
++index 4530a83aee..4e13e0d789 100644
++--- a/lib/runtime_tools/c_src/Makefile.in
+++++ b/lib/runtime_tools/c_src/Makefile.in
++@@ -95,7 +95,7 @@ $(OBJDIR)/%$(TYPEMARKER).o: %.c dyntrace_lttng.h
++ 	$(V_CC) -c -o $@ $(ALL_CFLAGS) $<
++ 
++ $(LIBDIR)/%$(TYPEMARKER).@DED_EXT@: $(OBJDIR)/%$(TYPEMARKER).o
++-	$(V_LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+++	$(V_LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
++ 
++ clean:
++ 	rm -f $(TRACE_LIBS)
++-- 
++2.14.1
++
+diff --git a/package/erlang/21.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+new file mode 100644
+index 0000000000..ccb1e8432f
+--- /dev/null
++++ b/package/erlang/21.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+@@ -0,0 +1,71 @@
++From f6217a2d195359a1956c20d2600b59d61be8f848 Mon Sep 17 00:00:00 2001
++From: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Date: Sun, 28 Dec 2014 23:39:40 +0100
++Subject: [PATCH] erts/ethread: instruct libatomic_ops we do require CAS
++
++We do require compare-and-swap (CAS), so we must instruct libatomic_ops
++to provide it, even if the architecture does not have instructions for
++it.
++
++For example, on ARM, LDREX is required for fast CAS. But LDREX is only
++available on ARMv6, so by default libatomic_ops will not have CAS for
++anything below, like ARMv5. But ARMv5 is always UP, so using an
++emulated CAS (that is signal-asyn-safe) is still possible (albeit much
++slower).
++
++Tell libatomic_ops to provide CAS, even if the hardware is not capable
++of it, by using emulated CAS, as per libatomic_ops dosc:
++    https://github.com/ivmai/libatomic_ops/blob/master/doc/README.txt#L28
++
++    If this is included after defining AO_REQUIRE_CAS, then the package
++    will make an attempt to emulate compare-and-swap in a way that (at
++    least on Linux) should still be async-signal-safe.
++
++Thanks go to Thomas for all this insight! :-)
++Thanks go to Frank for reporting the issue! :-)
++
++Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Cc: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Cc: Frank Hunleth <fhunleth@troodon-software.com>
++---
++ erts/aclocal.m4                               | 4 +++-
++ erts/include/internal/libatomic_ops/ethread.h | 1 +
++ 2 files changed, 4 insertions(+), 1 deletion(-)
++
++diff --git a/erts/aclocal.m4 b/erts/aclocal.m4
++index 80bf236..56d9dee 100644
++--- a/erts/aclocal.m4
+++++ b/erts/aclocal.m4
++@@ -1973,7 +1973,8 @@ case "$THR_LIB_NAME" in
++ 	    	    fi;;
++ 	    esac
++ 	    ethr_have_libatomic_ops=no
++-	    AC_TRY_LINK([#include "atomic_ops.h"],
+++	    AC_TRY_LINK([#define AO_REQUIRE_CAS
+++                    #include "atomic_ops.h"],
++ 	    	        [
++ 	    	    	    volatile AO_t x;
++ 	    	    	    AO_t y;
++@@ -2014,6 +2015,7 @@ case "$THR_LIB_NAME" in
++ 	        AC_CHECK_SIZEOF(AO_t, ,
++ 	    	    	        [
++ 	    	    	    	    #include <stdio.h>
+++	    	    	    	    #define AO_REQUIRE_CAS
++ 	    	    	    	    #include "atomic_ops.h"
++ 	    	    	        ])
++ 	        AC_DEFINE_UNQUOTED(ETHR_SIZEOF_AO_T, $ac_cv_sizeof_AO_t, [Define to the size of AO_t if libatomic_ops is used])
++diff --git a/erts/include/internal/libatomic_ops/ethread.h b/erts/include/internal/libatomic_ops/ethread.h
++index 4adc31e..18cc22a 100644
++--- a/erts/include/internal/libatomic_ops/ethread.h
+++++ b/erts/include/internal/libatomic_ops/ethread.h
++@@ -36,6 +36,7 @@
++ 
++ #define ETHR_NATIVE_IMPL__ "libatomic_ops"
++ 
+++#define AO_REQUIRE_CAS
++ #include "atomic_ops.h"
++ #include "ethr_membar.h"
++ #include "ethr_atomic.h"
++-- 
++2.7.4
++
+diff --git a/package/erlang/21.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/21.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+new file mode 100644
+index 0000000000..a2cecfbad2
+--- /dev/null
++++ b/package/erlang/21.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+@@ -0,0 +1,47 @@
++From 09b88921b947836834b62da41b18212cb92dc076 Mon Sep 17 00:00:00 2001
++From: Romain Naour <romain.naour@openwide.fr>
++Date: Sun, 8 Feb 2015 17:23:13 +0100
++Subject: [PATCH] erts/emulator: reorder inclued headers paths
++
++If the Perl Compatible Regular Expressions is installed on the
++host and the path to the headers is added to the CFLAGS, the
++pcre.h from the host is used instead of the one provided by
++erlang.
++
++Erlang use an old version of this file which is incompatible
++with the upstream one.
++
++Move INCLUDES before CFLAGS to use pcre.h from erlang.
++
++http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
++
++Signed-off-by: Romain Naour <romain.naour@openwide.fr>
++---
++ erts/emulator/Makefile.in | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
++index 0546928..38c2f05 100644
++--- a/erts/emulator/Makefile.in
+++++ b/erts/emulator/Makefile.in
++@@ -712,7 +712,7 @@ endif
++ # Usually the same as the default rule, but certain platforms (e.g. win32) mix
++ # different compilers
++ $(OBJDIR)/beam_emu.o: beam/beam_emu.c
++-	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ 
++ $(OBJDIR)/beam_emu.S: beam/beam_emu.c
++ 	$(V_EMU_CC) -S -fverbose-asm $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++@@ -765,7 +765,7 @@ endif
++ # General targets
++ #
++ $(OBJDIR)/%.o: beam/%.c
++-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ 
++ $(OBJDIR)/%.o: $(TARGET)/%.c
++ 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@
++-- 
++2.7.4
++
+diff --git a/package/erlang/21.0.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch b/package/erlang/21.0.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+new file mode 100644
+index 0000000000..391b6ebac2
+--- /dev/null
++++ b/package/erlang/21.0.5/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+@@ -0,0 +1,42 @@
++From 7baac8804d9441c1bc5db1115eccd290c8b99eda Mon Sep 17 00:00:00 2001
++From: Johan Oudinet <johan.oudinet@gmail.com>
++Date: Wed, 6 Dec 2017 15:01:17 +0100
++Subject: [PATCH] Link with LDLIBS instead of LIBS for DED
++
++Fix ERL-529 by avoiding to link with libz for no reason.
++
++Signed-off-by: Johan Oudinet <johan.oudinet@gmail.com>
++---
++ lib/asn1/c_src/Makefile             | 2 +-
++ lib/runtime_tools/c_src/Makefile.in | 2 +-
++ 2 files changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/lib/asn1/c_src/Makefile b/lib/asn1/c_src/Makefile
++index 1f714df..f7c6b8b 100644
++--- a/lib/asn1/c_src/Makefile
+++++ b/lib/asn1/c_src/Makefile
++@@ -126,7 +126,7 @@ $(NIF_LIB_FILE): $(NIF_STATIC_OBJ_FILES)
++ 	$(V_RANLIB) $@
++ 
++ $(NIF_SHARED_OBJ_FILE): $(NIF_OBJ_FILES)
++-	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LIBS)
+++	$(V_LD) $(LDFLAGS) -o $(NIF_SHARED_OBJ_FILE) $(NIF_OBJ_FILES) $(CLIB_FLAGS) $(LDLIBS)
++ 
++ # ----------------------------------------------------
++ # Release Target
++diff --git a/lib/runtime_tools/c_src/Makefile.in b/lib/runtime_tools/c_src/Makefile.in
++index 4530a83..4e13e0d 100644
++--- a/lib/runtime_tools/c_src/Makefile.in
+++++ b/lib/runtime_tools/c_src/Makefile.in
++@@ -95,7 +95,7 @@ $(OBJDIR)/%$(TYPEMARKER).o: %.c dyntrace_lttng.h
++ 	$(V_CC) -c -o $@ $(ALL_CFLAGS) $<
++ 
++ $(LIBDIR)/%$(TYPEMARKER).@DED_EXT@: $(OBJDIR)/%$(TYPEMARKER).o
++-	$(V_LD) $(LDFLAGS) -o $@ $^ $(LIBS)
+++	$(V_LD) $(LDFLAGS) -o $@ $^ $(LDLIBS)
++ 
++ clean:
++ 	rm -f $(TRACE_LIBS)
++-- 
++2.7.4
++
+diff --git a/package/erlang/Config.in b/package/erlang/Config.in
+index bf745555e8..2551eea65d 100644
+--- a/package/erlang/Config.in
++++ b/package/erlang/Config.in
+@@ -34,6 +34,24 @@ config BR2_PACKAGE_ERLANG
+ 
+ if BR2_PACKAGE_ERLANG
+ 
++choice
++	bool "Erlang/OTP version"
++	default BR2_PACKAGE_ERLANG_21
++	help
++	  Select the Erlang/OTP version
++
++config BR2_PACKAGE_ERLANG_20
++	bool "erlang 20"
++	help
++	  Use the latest Erlang/OTP 20 release
++
++config BR2_PACKAGE_ERLANG_21
++	bool "erlang 21"
++	help
++	  Use the latest Erlang/OTP 21 release
++
++endchoice
++
+ config BR2_PACKAGE_ERLANG_MEGACO
+ 	bool "install megaco application"
+ 	help
+diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
+index e453d667f9..d5e4eba148 100644
+--- a/package/erlang/erlang.hash
++++ b/package/erlang/erlang.hash
+@@ -1,2 +1,3 @@
+ # sha256 locally computed
+ sha256  70124f91693364f7fd2ec65baa45c434f069a14f5aa2c18377e1c3f320f47ac5  OTP-21.0.5.tar.gz
++sha256  a06d68aaf4884752d226410ff66547783c260bf4fc92147d60c4011465c1de24  OTP-20.3.8.5.tar.gz
+diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
+index 4c565513c0..8a1992334e 100644
+--- a/package/erlang/erlang.mk
++++ b/package/erlang/erlang.mk
+@@ -5,7 +5,12 @@
+ ################################################################################
+ 
+ # See note below when updating Erlang
++ifeq ($(BR2_PACKAGE_ERLANG_20),y)
++ERLANG_VERSION = 20.3.8.5
++else
+ ERLANG_VERSION = 21.0.5
++endif
++
+ ERLANG_SITE = https://github.com/erlang/otp/archive
+ ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
+ ERLANG_DEPENDENCIES = host-erlang host-autoconf
+@@ -14,9 +19,16 @@ ERLANG_LICENSE = Apache-2.0
+ ERLANG_LICENSE_FILES = LICENSE.txt
+ ERLANG_INSTALL_STAGING = YES
+ 
++ifeq ($(BR2_PACKAGE_ERLANG_20),y)
++# Patched erts/aclocal.m4
++ERLANG_AUTORECONF = YES
++
+ # Whenever updating Erlang, this value should be updated as well, to the
+ # value of EI_VSN in the file lib/erl_interface/vsn.mk
++ERLANG_EI_VSN = 3.10.2.1
++else
+ ERLANG_EI_VSN = 3.10.3
++endif
+ 
+ # The configure checks for these functions fail incorrectly
+ ERLANG_CONF_ENV = ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+-- 
+2.17.1
+


### PR DESCRIPTION
This adds support for OTP 20 back so that users who cannot upgrade to
OTP 21 can still follow along with the latest patches and security
updates.

The default remains OTP 21. OTP 20 must be explicitly chosen.