### PR TITLE
Add environment variable NERVES_DEVICE_PROVISION

### DIFF
--- a/nerves_env.exs
+++ b/nerves_env.exs
@@ -152,6 +152,9 @@ System.put_env("ERTS_INCLUDE_DIR", "#{erts_dir}/include")
 System.put_env("ERL_INTERFACE_LIB_DIR", Path.join(erl_interface_dir, "lib"))
 System.put_env("ERL_INTERFACE_INCLUDE_DIR", Path.join(erl_interface_dir, "include"))
 
+# Nerves device provisioning
+System.put_env("NERVES_DEVICE_PROVISION", Path.join(system_path, "images/fwup-include/provision.conf"))
+
 host_erl_major_ver = :erlang.system_info(:otp_release) |> to_string
 [target_erl_major_version | _] =
   sdk_sysroot

--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -129,6 +129,9 @@ export ERTS_INCLUDE_DIR="$ERTS_DIR/include"
 export ERL_INTERFACE_LIB_DIR="$ERL_INTERFACE_DIR/lib"
 export ERL_INTERFACE_INCLUDE_DIR="$ERL_INTERFACE_DIR/include"
 
+# Nerves device provisioning
+export NERVES_DEVICE_PROVISION="$NERVES_SYSTEM/images/fwup-include/provision.conf"
+
 # Since it is so important that the host and target Erlang installs
 # match, check it here.
 NERVES_HOST_ERL_MAJOR_VER_RAW=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell)


### PR DESCRIPTION
This variable will be used for pointing to a file that fwup configs can use for detailing additional key value pairs set during device provisioning.