### PR TITLE
Docker image updates

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -68,16 +68,13 @@ RUN dpkg --add-architecture i386 \
     bc \
     squashfs-tools \
     gnupg \
+    libmnl-dev \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \
   && apt-get -y install \
     "esl-erlang=1:${ERLANG_OTP_VERSION}" \
   && rm -rf /var/lib/apt/lists/* \
-  && wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb \
-  && dpkg -i fwup_${FWUP_VERSION}_amd64.deb \
-  && rm -f *.tar.gz \
-  && rm -f fwup_${FWUP_VERSION}_amd64.deb \
   && mkdir -p /root/.ssh \
   && ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts \
   && chmod 700 /root/.ssh \
@@ -86,5 +83,10 @@ RUN dpkg --add-architecture i386 \
   && apt-get -q -y autoremove \
   && apt-get -q -y clean \
   && mkdir -p /nerves/build && chmod 777 /nerves/build
+
+RUN wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb \
+  && dpkg -i fwup_${FWUP_VERSION}_amd64.deb \
+  && rm -f *.tar.gz \
+  && rm -f fwup_${FWUP_VERSION}_amd64.deb
 
 ENTRYPOINT [ "/nerves/docker-entrypoint.sh" ]

--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -6,6 +6,7 @@ if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0"
   echo "UID: $UID"
   echo "GID: $GID"
 
+  groupadd -g $GID nerves
   useradd -g $GID -u $UID -m nerves
   echo "Switching user"
   su nerves


### PR DESCRIPTION
Trying to accomplish the following
1. Fix an issue with docker running on linux hosts where it would raise an exception that the group id for 1000 does not exist. This is an issue in the docker-entrypoint script. The PR adds the group before trying to add the user to it.
2. Improve docker image layer caching. Since fwup changes more frequently then the reset of the host packages, I am splitting it out in an attempt to see if it can reuse the other layers. I am hoping that this shrinks an 800mb download on every bump to roughly the size of fwup. 
3. Add `libmnl-dev` for building nerves project apps using this image.