### PR TITLE
erlinit: bump to v1.4.6

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,2 +1,3 @@
 # Locally computed
-sha256 e1b5e3c38413ecb85d4f766590f0ca8b71e842e152fb0481b14dc3469d5697ed  erlinit-v1.4.5.tar.gz
+sha256 539d794d24d498b0b0db0193db7ba07fa722cb3b8429444339657f992bd5f4ea  erlinit-v1.4.6.tar.gz
+sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.5
+ERLINIT_VERSION = v1.4.6
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This also adds a hash for the LICENSE file for 'make legal-info'.