### PR TITLE
Set the group and user even if it exists

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -28,6 +28,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8 C.UTF-8/' /etc/locale.gen
 RUN dpkg --add-architecture i386 \
   && apt-get update -y -qq \
   && apt-get install -y -qq \
+    gosu \
     bzr \
     ca-certificates \
     cvs \

--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -10,7 +10,10 @@ if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0"
   useradd -o -g $GID -u $UID -m nerves
 
   echo "Switching user"
-  su nerves
+
+  gosu nerves $@
+else
+  exec "$@"
 fi
 
-exec "$@"
+

--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -6,8 +6,9 @@ if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0"
   echo "UID: $UID"
   echo "GID: $GID"
 
-  groupadd -g $GID nerves
-  useradd -g $GID -u $UID -m nerves
+  groupadd -o -g $GID nerves
+  useradd -o -g $GID -u $UID -m nerves
+
   echo "Switching user"
   su nerves
 fi


### PR DESCRIPTION
use `-o` to fix issues with setting groups that already exist `groupadd: GID '20' already exists`