### PR TITLE
Use single sed call with multiple -e's

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -54,7 +54,7 @@ owner_to_uid_gid() {
 
 get_path() {
     # trim the squashfs-root and escape any spaces
-    echo $* | sed -e 's/squashfs-root//' | sed -e 's/ /\\ /g'
+    echo $* | sed -e 's/squashfs-root//' -e 's/ /\\ /g'
 }
 
 device_file() {
@@ -120,7 +120,7 @@ unsquash_to_pseudofile() {
 find_to_pseudofile() {
     inputdir=$1
     while read mode path; do
-        path=$(echo $path | sed -e "s^$inputdir^^" | sed -e "s/ /\\\\ /g")
+        path=$(echo $path | sed -e "s^$inputdir^^" -e "s/ /\\\\ /g")
         if [[ ! -z $path ]]; then
             echo "$path m $mode 0 0"
         fi


### PR DESCRIPTION
Piping multiple sed calls together can result in extreme slowness on some systems.  However, the same result can be accomplished more efficiently by using a single call to sed with multiple scripts passed in (see https://www.gnu.org/software/sed/manual/sed.html#Multiple-commands-syntax)

This change reduced `mix firmware` runtime from 30+ minutes to < 2 minutes on my system (MacOS High Sierra 10.13.6).