### PR TITLE
nerves_heart: bump to v0.2.0

### DIFF
--- a/package/nerves_heart/nerves_heart.hash
+++ b/package/nerves_heart/nerves_heart.hash
@@ -1,2 +1,3 @@
 # Locally computed
-sha256 662a20700334b2d771d7de6d2dd8da172f2c4099dea074cb7a2b3ecae5698fde  nerves_heart-v0.1.0.tar.gz
+sha256 8281aa0a40e5d401c5949365d8993779ea624f2fe020908289c2ea58f0a92e72  nerves_heart-v0.2.0.tar.gz
+sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE

--- a/package/nerves_heart/nerves_heart.mk
+++ b/package/nerves_heart/nerves_heart.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-NERVES_HEART_VERSION = v0.1.0
+NERVES_HEART_VERSION = v0.2.0
 NERVES_HEART_SITE = $(call github,nerves-project,nerves_heart,$(NERVES_HEART_VERSION))
 NERVES_HEART_LICENSE = MIT
 NERVES_HEART_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This changes logging to write to the kernel log buffer if it's available
so that heart output isn't lost with Nerves. It also merges in an
upstream fix.