### PR TITLE
boardid: bump to v1.2.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 cef56a669b9483109768ab194576fd9c038044dee6280e4797f63cdfb3b0439b  boardid-v1.1.1.tar.gz
+sha256 842e6acd32b9ad06e194f6d6c805065a1ba403c65f500780eddd3901aa93449a  boardid-v1.2.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.1.1
+BOARDID_VERSION = v1.2.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This version adds support for querying serial numbers from the ATECC508A
CryptoAuthentication device.