### PR TITLE
bborg-overlays: bump to f3d81bb934b

### DIFF
--- a/package/bborg-overlays/bborg-overlays.hash
+++ b/package/bborg-overlays/bborg-overlays.hash
@@ -1,0 +1,2 @@
+# Locally computed
+sha256 912b01d86d972d165e4552a10bfd78aa4387a39258abab9de8a3fde01d393dca  bborg-overlays-f3d81bb934b1be9f532e31101b2e3f54b4488f14.tar.gz

--- a/package/bborg-overlays/bborg-overlays.mk
+++ b/package/bborg-overlays/bborg-overlays.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BBORG_OVERLAYS_VERSION = 604c0926a4f7505dfc3d501301413c821e59febe
+BBORG_OVERLAYS_VERSION = f3d81bb934b1be9f532e31101b2e3f54b4488f14
 BBORG_OVERLAYS_SITE = $(call github,beagleboard,bb.org-overlays,$(BBORG_OVERLAYS_VERSION))
 BBORG_OVERLAYS_LICENSE = GPLv2
 BBORG_OVERLAYS_DEPENDENCIES = host-dtc


### PR DESCRIPTION
This is the current latest version of the Beagleboard device tree
overlay set.