### PR TITLE
Revert to dtc 1.4.4

### DIFF
--- a/patches/buildroot/0014-Revert-dtc-bump-version-to-1.4.7.patch
+++ b/patches/buildroot/0014-Revert-dtc-bump-version-to-1.4.7.patch
@@ -1,0 +1,37 @@
+From 0488527c0bd88eff1a3523a4465dce99e2b35032 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Fri, 21 Sep 2018 17:57:57 -0400
+Subject: [PATCH] Revert "dtc: bump version to 1.4.7"
+
+This reverts commit 7b929ddcf0812310d0113cf3675429dbd123aa99.
+
+I give up on trying to backport the 1.4.7 changes to pre-4.17 kernels.
+---
+ package/dtc/dtc.hash | 2 +-
+ package/dtc/dtc.mk   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/dtc/dtc.hash b/package/dtc/dtc.hash
+index b402c2249b..75c2e40eea 100644
+--- a/package/dtc/dtc.hash
++++ b/package/dtc/dtc.hash
+@@ -1,2 +1,2 @@
+ # from https://www.kernel.org/pub/software/utils/dtc/sha256sums.asc
+-sha256 6643e8f00ff86350f465bb54b2185058b5b1b7bac01a0842c81a52b86589cde7 dtc-1.4.7.tar.xz
++sha256 470731d5c015b160d26a96645dbb1c7337d6e7b8c98244612002b66bedf6cffb  dtc-1.4.4.tar.xz
+diff --git a/package/dtc/dtc.mk b/package/dtc/dtc.mk
+index 7cb879bff4..9767766bcf 100644
+--- a/package/dtc/dtc.mk
++++ b/package/dtc/dtc.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-DTC_VERSION = 1.4.7
++DTC_VERSION = 1.4.4
+ DTC_SOURCE = dtc-$(DTC_VERSION).tar.xz
+ DTC_SITE = https://www.kernel.org/pub/software/utils/dtc
+ DTC_LICENSE = GPL-2.0+ or BSD-2-Clause (library)
+-- 
+2.17.1
+


### PR DESCRIPTION
The steps to make Linux kernels before 4.17 work with dtc 1.4.7 was too
frustrating, so I gave up. I did try other versions of dtc. dtc 1.4.5
crashes and 1.4.6 fails similar in a similar manner to 1.4.7.