### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -6,7 +6,10 @@
 #
 
 set -e
+
 LC_ALL=C
+LANG=C
+export LC_ALL LANG
 
 # Account for Mac differences
 if [[ "$(uname)" = "Darwin" ]]; then
@@ -49,12 +52,12 @@ perm_to_num() {
 }
 
 owner_to_uid_gid() {
-    echo $1 | sed -e "s/\// /g"
+    echo "$1" | sed -e "s/\// /g"
 }
 
 get_path() {
     # trim the squashfs-root and escape any spaces
-    echo $* | sed -e 's/squashfs-root//' -e 's/ /\\ /g'
+    echo "$*" | sed -e 's/squashfs-root//' -e 's/ /\\ /g'
 }
 
 device_file() {
@@ -65,62 +68,64 @@ device_file() {
     # major,minor or major, minor. Remove the comma and account
     # for the optional space.
     if [[ $3 =~ ,.+ ]]; then
-        major_minor=$(echo $3 | sed -e 's/,/ /')
+        major_minor=$(echo "$3" | sed -e 's/,/ /')
         filename=$6
     else
-        major_minor="$(echo $3 | sed -e 's/,/ /') $4"
+        major_minor="$(echo "$3" | sed -e 's/,/ /') $4"
         filename=$7
     fi
 
-    echo "$(get_path $filename) ${perm:0:1} $(perm_to_num $perm) $(owner_to_uid_gid $owner) $major_minor"
+    echo "$(get_path "$filename") ${perm:0:1} $(perm_to_num "$perm") $(owner_to_uid_gid "$owner") $major_minor"
 }
 
 symlink_file() {
     # symlinks are the handled the same as files currently.
-    echo "$(get_path $6) m $(perm_to_num $1) $(owner_to_uid_gid $2)"
+    echo "$(get_path "$6") m $(perm_to_num "$1") $(owner_to_uid_gid "$2")"
 }
 
 directory_file() {
-    pathname=$(get_path $6)
+    pathname=$(get_path "$6")
     # mksquashfs doesn't support setting permissions and ownership
     # on the root directory
     if [[ ! -z $pathname ]]; then
-        echo "$pathname m $(perm_to_num $1) $(owner_to_uid_gid $2)"
+        echo "$pathname m $(perm_to_num "$1") $(owner_to_uid_gid "$2")"
     fi
 }
 
 regular_file() {
-    echo "$(get_path $6) m $(perm_to_num $1) $(owner_to_uid_gid $2)"
+    echo "$(get_path "$6") m $(perm_to_num "$1") $(owner_to_uid_gid "$2")"
 }
 
 unsquash_to_pseudofile() {
     input=$1
-    while read perms owner rest; do
+    while read -r perms owner rest; do
         case $perms in
             c*)
-                device_file $perms $owner $rest
+                device_file "$perms" "$owner" $rest
                 ;;
             b*)
-                device_file $perms $owner $rest
+                device_file "$perms" "$owner" $rest
                 ;;
             l*)
-                symlink_file $perms $owner $rest
+                symlink_file "$perms" "$owner" $rest
                 ;;
             d*)
-                directory_file $perms $owner $rest
+                directory_file "$perms" "$owner" $rest
                 ;;
             -*)
-                regular_file $perms $owner $rest
+                regular_file "$perms" "$owner" $rest
                 ;;
             *)
+                # Ignore
+                ;;
         esac
-    done < <(unsquashfs -n -ll $input)
+    done < <(unsquashfs -n -ll "$input")
 }
 
 find_to_pseudofile() {
     inputdir=$1
-    while read mode path; do
-        path=$(echo $path | sed -e "s^$inputdir^^" -e "s/ /\\\\ /g")
+    while read -r mode path; do
+        path=$(echo "$path" | sed -e "s^$inputdir^^" -e "s/ /\\\\ /g")
         if [[ ! -z $path ]]; then
             echo "$path m $mode 0 0"
         fi
@@ -136,7 +141,7 @@ readlink_f () {
     if [[ -h "$filename" ]]; then
         readlink_f "$(readlink "$filename")"
     else
-        echo "`pwd -P`/$filename"
+        echo "$(pwd -P)/$filename"
     fi
 }
 
@@ -158,8 +163,8 @@ if [[ ! -d $overlay_dir ]]; then
     exit 1
 fi
 
-workdir=`mktemp -d 2>/dev/null || mktemp -d -t 'merge-squashfs-tmp'`
-pushd $workdir >/dev/null
+workdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'merge-squashfs-tmp')
+pushd "$workdir" >/dev/null
 
 unsquash_to_pseudofile "$input_squashfs" >pseudofile.in
 find_to_pseudofile "$overlay_dir" >>pseudofile.in
@@ -173,4 +178,4 @@ mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -noappend -no-recover
 
 # cleanup
 popd >/dev/null
-rm -fr $workdir
+rm -fr "$workdir"

--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -24,7 +24,7 @@ if [ -e $NERVES_SYSTEM/host ]; then
     # This is a Linux Buildroot build, so use tools as
     # provided by Buildroot
     NERVES_TOOLCHAIN=$NERVES_SYSTEM/host
-    ALL_CROSSCOMPILE=`ls $NERVES_TOOLCHAIN/usr/bin/*gcc | sed -e s/-gcc//`
+    ALL_CROSSCOMPILE=$(ls "$NERVES_TOOLCHAIN"/usr/bin/*gcc | sed -e s/-gcc//)
 
     # For Buildroot builds, use the Buildroot provided versions of pkg-config
     # and perl.
@@ -34,19 +34,19 @@ if [ -e $NERVES_SYSTEM/host ]; then
 
     export PERLLIB=$NERVES_TOOLCHAIN/usr/lib/perl
 
-    pathadd $NERVES_TOOLCHAIN/usr/bin
-    pathadd $NERVES_TOOLCHAIN/usr/sbin
-    pathadd $NERVES_TOOLCHAIN/bin
-    ldlibrarypathadd $NERVES_TOOLCHAIN/usr/lib
+    pathadd "$NERVES_TOOLCHAIN/usr/bin"
+    pathadd "$NERVES_TOOLCHAIN/usr/sbin"
+    pathadd "$NERVES_TOOLCHAIN/bin"
+    ldlibrarypathadd "$NERVES_TOOLCHAIN/usr/lib"
 else
     # The user is using a prebuilt toolchain and system. Usually NERVES_TOOLCHAIN will be defined,
     # but guess it just in case it isn't.
     if [ -z $NERVES_TOOLCHAIN ]; then
         NERVES_TOOLCHAIN=$NERVES_SYSTEM/../nerves-toolchain
     fi
-    ALL_CROSSCOMPILE=`ls $NERVES_TOOLCHAIN/bin/*gcc | sed -e s/-gcc//`
+    ALL_CROSSCOMPILE=$(ls "$NERVES_TOOLCHAIN"/bin/*gcc | sed -e s/-gcc//)
 
-    pathadd $NERVES_TOOLCHAIN/bin
+    pathadd "$NERVES_TOOLCHAIN/bin"
 fi
 
 # Verify that a crosscompiler was found.
@@ -80,14 +80,14 @@ export NERVES_SDK_SYSROOT
 # Rebar environment variables
 #PLATFORM_DIR=$NERVES_ROOT/sdk/$NERVES_PLATFORM # Update when this is determined
 
-ERTS_DIR=`ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/erts-*`
-ERL_INTERFACE_DIR=`ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/lib/erl_interface-*`
+ERTS_DIR=$(ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/erts-*)
+ERL_INTERFACE_DIR=$(ls -d $NERVES_SDK_SYSROOT/usr/lib/erlang/lib/erl_interface-*)
 # We usually just have one crosscompiler, but the buildroot toolchain symlinks
 # to the crosscompiler, so two entries show up. The logic below picks the first
 # crosscompiler by default or the one with buildroot in its name.
-CROSSCOMPILE=`echo $ALL_CROSSCOMPILE | head -n 1`
+CROSSCOMPILE=$(echo "$ALL_CROSSCOMPILE" | head -n 1)
 for i in $ALL_CROSSCOMPILE; do
-    case `basename $i` in
+    case $(basename $i) in
         *buildroot* )
             CROSSCOMPILE=$i
             ;;
@@ -113,7 +113,7 @@ export LDFLAGS="--sysroot=$NERVES_SDK_SYSROOT"
 export STRIP=$CROSSCOMPILE-strip
 export ERL_CFLAGS="-I$ERTS_DIR/include -I$ERL_INTERFACE_DIR/include"
 export ERL_LDFLAGS="-L$ERTS_DIR/lib -L$ERL_INTERFACE_DIR/lib -lerts -lerl_interface -lei"
-export REBAR_TARGET_ARCH=$(basename $CROSSCOMPILE)
+export REBAR_TARGET_ARCH="$(basename "$CROSSCOMPILE")"
 
 # Qt/QMake
 if [ -e "$NERVES_SDK_SYSROOT/mkspecs/devices/linux-buildroot-g++" ]; then
@@ -136,7 +136,7 @@ NERVES_HOST_ERL_MAJOR_VER=${NERVES_HOST_ERL_MAJOR_VER_RAW//\"}       # Trim doub
 NERVES_HOST_ERL_MAJOR_VER=${NERVES_HOST_ERL_MAJOR_VER//[[:space:]]/} # Trim whitespace
 
 # The OTP_VERSION file's location depends on where erl is located. Try both locations
-ERL_DIR=$(dirname $(which erl))
+ERL_DIR=$(dirname "$(command -v erl)")
 HOST_OTP_VERSION_PATH=$ERL_DIR/../lib/erlang/releases/$NERVES_HOST_ERL_MAJOR_VER/OTP_VERSION
 [ -e "$HOST_OTP_VERSION_PATH" ] || HOST_OTP_VERSION_PATH=$ERL_DIR/../../releases/$NERVES_HOST_ERL_MAJOR_VER/OTP_VERSION
 
@@ -159,8 +159,8 @@ if [ "$NERVES_HOST_ERL_MAJOR_VER" != "$NERVES_TARGET_ERL_MAJOR_VER" ]; then
     echo
     echo "Example:"
     echo "  Your host has Erlang OTP 20 and your target is a rpi0."
-    echo "  The latest version of `nerves_system_rpi0` is say, `v1.2.0` and it"
-    echo "  uses Erlang OTP 21. You can try downgrading a release, to `v1.1.1` where"
+    echo "  The latest version of \`nerves_system_rpi0\` is say, \`v1.2.0\` and it"
+    echo "  uses Erlang OTP 21. You can try downgrading a release, to \`v1.1.1\` where"
     echo "  the Erlang OTP version is 20."
     echo
     return 1

--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -2,7 +2,7 @@
 set -e
 
 BASE_DIR=$(pwd)
-PROJECT_DIR=$(basename $BASE_DIR)
+PROJECT_DIR=$(basename "$BASE_DIR")
 
 SCRIPT_NAME=$0
 
@@ -87,7 +87,7 @@ if [[ ! -e "$MKSQUASHFS" ]]; then
 fi
 
 TMP_DIR=$BASE_DIR/_nerves-tmp
-rm -fr $TMP_DIR
+rm -fr "$TMP_DIR"
 
 # Fill in defaults
 [[ -z "$FW_FILENAME" ]] && FW_FILENAME=${PROJECT_DIR}.fw
@@ -104,7 +104,7 @@ if [[ ! -d "$RELEASE_DIR/lib" || ! -d "$RELEASE_DIR/releases" ]]; then
 fi
 
 # Make sure that the firmware output directories are there.
-mkdir -p $(dirname "$FW_FILENAME")
+mkdir -p "$(dirname "$FW_FILENAME")"
 
 # Update the file system bundle
 echo "Updating base firmware image with Erlang release..."
@@ -117,7 +117,7 @@ mkdir -p "$TMP_DIR/rootfs-additions/srv/erlang"
 cp -R "$RELEASE_DIR/." "$TMP_DIR/rootfs-additions/srv/erlang"
 
 # Clean up the Erlang release of all the files that we don't need.
-$NERVES_SYSTEM/scripts/scrub-otp-release.sh "$TMP_DIR/rootfs-additions/srv/erlang"
+"$NERVES_SYSTEM/scripts/scrub-otp-release.sh" "$TMP_DIR/rootfs-additions/srv/erlang"
 
 # Copy over any rootfs additions from the user
 # IMPORTANT: This must be the final step before the merge so that the user can
@@ -135,7 +135,7 @@ if [[ "$ROOTFS_ADDITIONS" ]]; then
 fi
 
 # Merge the Erlang/OTP release onto the base image
-$NERVES_SYSTEM/scripts/merge-squashfs "$NERVES_SDK_IMAGES/rootfs.squashfs" "$TMP_DIR/combined.squashfs" "$TMP_DIR/rootfs-additions"
+"$NERVES_SYSTEM/scripts/merge-squashfs" "$NERVES_SDK_IMAGES/rootfs.squashfs" "$TMP_DIR/combined.squashfs" "$TMP_DIR/rootfs-additions"
 
 # Build the firmware image
 echo "Building $FW_FILENAME..."
@@ -144,7 +144,7 @@ ROOTFS="$TMP_DIR/combined.squashfs" $FWUP -c -f "$FWUP_CONFIG" \
 
 if [[ ! -z "$IMG_FILENAME" ]]; then
     # Create the output directory - just in case
-    mkdir -p $(dirname "$IMG_FILENAME")
+    mkdir -p "$(dirname "$IMG_FILENAME")"
 
     # Erase the image file in case it exists from a previous build.
     # We use fwup in "programming" mode to create the raw image so it expects there

--- a/scripts/scrub-target.sh
+++ b/scripts/scrub-target.sh
@@ -18,7 +18,7 @@ fi
 
 # All of the Erlang libraries get included from the release (/srv/erlang), so
 # we don't need anything in here.
-rm -fr $TARGET_DIR/usr/lib/erlang/lib/*
+rm -fr "$TARGET_DIR"/usr/lib/erlang/lib/*
 
 # Remove all shell scripts. We're trying hard not to ever have to run
 # one, so this keeps us honest in the base image.
@@ -27,46 +27,46 @@ rm -fr $TARGET_DIR/usr/lib/erlang/lib/*
 #find $TARGET_DIR -type f | xargs file | grep "POSIX shell script" | cut -d : -f 1 | xargs rm -f
 
 # Remove shell script configuration
-rm -f $TARGET_DIR/root/.bash* $TARGET_DIR/etc/profile $TARGET_DIR/etc/issue
-rm -fr $TARGET_DIR/usr/share/bash-completion
+rm -f "$TARGET_DIR"/root/.bash* "$TARGET_DIR/etc/profile" "$TARGET_DIR/etc/issue"
+rm -fr "$TARGET_DIR/usr/share/bash-completion"
 
 # Remove sys v init configs since Nerves doesn't run Busybox init
 # NOTE: Can't remove inittab without causing a buildroot error when
 # it configures whether to mount to root file system read/write
-rm -fr $TARGET_DIR/etc/init.d $TARGET_DIR/etc/random-seed $TARGET_DIR/etc/network
+rm -fr "$TARGET_DIR/etc/init.d" "$TARGET_DIR/etc/random-seed" "$TARGET_DIR/etc/network"
 
 # Remove the Buildroot default wpa_supplicant.conf since it is
 # wrong and confusing. The wpa_supplicant.conf file must be
 # dynamically created based on the regulatory domain, so it
 # shouldn't be in a root filesystem anyway.
-rm -f $TARGET_DIR/etc/wpa_supplicant.conf
+rm -f "$TARGET_DIR/etc/wpa_supplicant.conf"
 
 # Remove the Buildroot default fstab since it isn't used.
 # erlinit mounts the pseudo filesystems automatically and it
 # has parameters to do a best-effort mount attempt on real
 # partitions. Erlang/Elixir applications need to handle
 # anything complicated.
-rm -f $TARGET_DIR/etc/fstab
+rm -f "$TARGET_DIR/etc/fstab"
 
 # Remove Erlang binaries that don't make sense on the target
-find $TARGET_DIR -name ct_run -exec rm "{}" ";"
-find $TARGET_DIR -name dialyzer -exec rm "{}" ";"
-find $TARGET_DIR -name erlc -exec rm "{}" ";"
-find $TARGET_DIR -name escript -exec rm "{}" ";"
-find $TARGET_DIR -name run_erl -exec rm "{}" ";"
-find $TARGET_DIR -name to_erl -exec rm "{}" ";"
-find $TARGET_DIR -name typer -exec rm "{}" ";"
+find "$TARGET_DIR" -name ct_run -exec rm "{}" ";"
+find "$TARGET_DIR" -name dialyzer -exec rm "{}" ";"
+find "$TARGET_DIR" -name erlc -exec rm "{}" ";"
+find "$TARGET_DIR" -name escript -exec rm "{}" ";"
+find "$TARGET_DIR" -name run_erl -exec rm "{}" ";"
+find "$TARGET_DIR" -name to_erl -exec rm "{}" ";"
+find "$TARGET_DIR" -name typer -exec rm "{}" ";"
 
 # Remove soft links that aren't used
-rm -f $TARGET_DIR/usr/bin/erl $TARGET_DIR/usr/bin/epmd
+rm -f "$TARGET_DIR/usr/bin/erl" "$TARGET_DIR/usr/bin/epmd"
 
 # Remove libatomic_ops readme files
-rm -fr $TARGET_DIR/usr/share/libatomic_ops
+rm -fr "$TARGET_DIR/usr/share/libatomic_ops"
 
 # Prune empty directories
-find $TARGET_DIR/etc -type d -empty -delete
-find $TARGET_DIR/usr -type d -empty -delete
-echo "If the next line fails, add the following to nerves_defconfig and build clean (sorry):"
+find "$TARGET_DIR/etc" -type d -empty -delete
+find "$TARGET_DIR/usr" -type d -empty -delete
+echo 'If the next line fails, add the following to nerves_defconfig and build clean (sorry):'
 echo '  BR2_ROOTFS_SKELETON_CUSTOM=y'
 echo '  BR2_ROOTFS_SKELETON_CUSTOM_PATH="${BR2_EXTERNAL_NERVES_PATH}/board/nerves-common/skeleton"'
-find $TARGET_DIR/var -type d -empty -delete
+find "$TARGET_DIR/var" -type d -empty -delete


### PR DESCRIPTION
This should help users that have whitespace in paths leading to build
directories. I don't think that it will have any other effect.