### PR TITLE
fwup: bump to v1.2.6

### DIFF
--- a/patches/buildroot/0014-fwup-bump-to-v1.2.6.patch
+++ b/patches/buildroot/0014-fwup-bump-to-v1.2.6.patch
@@ -1,0 +1,35 @@
+From 37312722b5dd2160794aa9f519941ad4d53faa06 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 4 Oct 2018 23:12:34 -0400
+Subject: [PATCH] fwup: bump to v1.2.6
+
+---
+ package/fwup/fwup.hash | 2 +-
+ package/fwup/fwup.mk   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
+index 73bff448de..0c596771e5 100644
+--- a/package/fwup/fwup.hash
++++ b/package/fwup/fwup.hash
+@@ -1,3 +1,3 @@
+ # Locally calculated
+-sha256 20302dc96cef88438034e15551e178bb0652c28d99aa7ca5260100cb3bebbc2a  fwup-v1.2.5.tar.gz
++sha256 5bdcb8a5424b211fd35ddd4d8fdd6f74e8221cf432807dc8018f81ce54939b52  fwup-v1.2.6.tar.gz
+ sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
+diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
+index be0b1d13b8..d43a250b3b 100644
+--- a/package/fwup/fwup.mk
++++ b/package/fwup/fwup.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-FWUP_VERSION = v1.2.5
++FWUP_VERSION = v1.2.6
+ FWUP_SITE = $(call github,fhunleth,fwup,$(FWUP_VERSION))
+ FWUP_LICENSE = Apache-2.0
+ FWUP_LICENSE_FILES = LICENSE
+-- 
+2.17.1
+


### PR DESCRIPTION
The difference between 1.2.5 and 1.2.6 shouldn't affect Nerves. The
changes were to fix a compiler error that doesn't affect Nerves, to fix
a bug on OSX, and improve a couple issues in shell scripts.

This patch isn't included in the existing fwup version patch since that
one has been accepted to Buildroot and will disappear on the next BR
update.