### PR TITLE
erlinit: bump to v1.4.7

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 539d794d24d498b0b0db0193db7ba07fa722cb3b8429444339657f992bd5f4ea  erlinit-v1.4.6.tar.gz
+sha256 17cf84aab64a8fa4a598d2d43e5faabd430e8280e494ec948af39b95d4d83e0b  erlinit-v1.4.7.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.6
+ERLINIT_VERSION = v1.4.7
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This fixes an issue with detecting root disks on NVME-connected drives.