### PR TITLE
Fix scrubber missing OSX executables

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -57,28 +57,40 @@ find "$RELEASE_DIR/releases" \( -name "*.sh" \
 # Scrub the executables
 #
 
-readelf_headers()
-{
-    if ! "$READELF" -h "$1" 2>/dev/null; then
-        echo "not_elf"
-    fi
-}
-
 executable_type()
 {
-    FILE="$1"
-    READELF_OUTPUT="$2"
+    FILE=$1
 
-    ELF_MACHINE=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Machine: +(.+)/!d; s//\1/;' | head -1)
-    ELF_FLAGS=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Flags: +(.+)/!d; s//\1/;' | head -1)
+    # Try readelf first, since it's output seems more trustworthy for executables
+    READELF_OUTPUT=$("$READELF" -h "$FILE" 2>/dev/null || true)
+    if [ "$READELF_OUTPUT" ]; then
+        ELF_MACHINE=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Machine: +(.+)/!d; s//\1/;' | head -1)
+        ELF_FLAGS=$(echo "$READELF_OUTPUT" | sed -E -e '/^  Flags: +(.+)/!d; s//\1/;' | head -1)
 
-    if [ -z "$ELF_MACHINE" ]; then
-        echo "$SCRIPT_NAME: ERROR: Didn't expect empty machine field in ELF header in $FILE." 1>&2
-        echo "   Try running '$READELF -h $FILE' and" 1>&2
-        echo "   and create an issue at https://github.com/nerves-project/nerves_system_br/issues." 1>&2
-        exit 1
+        if [ -z "$ELF_MACHINE" ]; then
+            echo "$SCRIPT_NAME: ERROR: Didn't expect empty machine field in ELF header in $FILE." 1>&2
+            echo "   Try running '$READELF -h $FILE' and" 1>&2
+            echo "   and create an issue at https://github.com/nerves-project/nerves_system_br/issues." 1>&2
+            exit 1
+        fi
+        echo "readelf:$ELF_MACHINE;$ELF_FLAGS"
+    else
+        # readelf didn't work, so try file and guess at things that will cause problems
+        FILE_OUTPUT=$(file -b -h "$FILE")
+        case "$FILE_OUTPUT" in
+            *shared*library*)
+                echo "file:$FILE_OUTPUT"
+                ;;
+
+            *x86_64*)
+                echo "file:$FILE_OUTPUT"
+                ;;
+
+            *)
+                echo "portable"
+                ;;
+        esac
     fi
-    echo "$ELF_MACHINE;$ELF_FLAGS"
 }
 
 get_expected_executable_type()
@@ -87,7 +99,7 @@ get_expected_executable_type()
     # so that we know what the `file` output should look like.
     tmpfile=$(mktemp /tmp/scrub-otp-release.XXXXXX)
     echo "int main() {}" | "$CROSSCOMPILE-gcc" -x c -o "$tmpfile" -
-    executable_type "$tmpfile" "$(readelf_headers "$tmpfile")"
+    executable_type "$tmpfile"
     rm "$tmpfile"
 }
 
@@ -95,10 +107,9 @@ EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100)
 EXPECTED_TYPE=$(get_expected_executable_type)
 
 for EXECUTABLE in $EXECUTABLES; do
-    READELF_OUTPUT=$(readelf_headers "$EXECUTABLE")
-    if [ "$READELF_OUTPUT" != "not_elf" ]; then
+    TYPE=$(executable_type "$EXECUTABLE")
+    if [ "$TYPE" != "portable" ]; then
         # Verify that the executable was compiled for the target
-        TYPE=$(executable_type "$EXECUTABLE" "$READELF_OUTPUT")
         if [ "$TYPE" != "$EXPECTED_TYPE" ]; then
             echo "$SCRIPT_NAME: ERROR: Unexpected executable format for '$EXECUTABLE'"
             echo

--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -17,14 +17,14 @@ if [ ! -d "$RELEASE_DIR" ]; then
     exit 1
 fi
 
-if [ ! -d "$RELEASE_DIR/lib" -o ! -d "$RELEASE_DIR/releases" ]; then
+if [ ! -d "$RELEASE_DIR/lib" ] || [ ! -d "$RELEASE_DIR/releases" ]; then
     echo "$SCRIPT_NAME: ERROR: Expecting '$RELEASE_DIR' to contain 'lib' and 'releases' subdirectories"
     exit 1
 fi
 
 STRIP="$CROSSCOMPILE-strip"
 READELF="$CROSSCOMPILE-readelf"
-if [ ! -e "$STRIP" -o ! -e "$READELF" ]; then
+if [ ! -e "$STRIP" ] || [ ! -e "$READELF" ]; then
     echo "$SCRIPT_NAME: ERROR: Expecting \$CROSSCOMPILE to be set. Did you source nerves-env.sh?"
     echo "  \"mix firmware\" should do this for you. Please file an issue is using \"mix\"."
     echo "  Additional information:"


### PR DESCRIPTION
It turns out that `readelf` fails on OSX executables so there was a
regression on being able to detect them in releases. This changes the
logic so that `readelf` is tried first. It gives the most reliable
information. If `readelf` fails, then there's likely something wrong if
the file isn't a shell script. This uses `file` to figure that out and
guesses if x86_64 is in the output or "shared library" that something is
wrong. Everything else is assumed to be ok. Note that x86_64 is checked
after the readelf check so even on x86_64 devices, this check should be
ok.

Here's a sample of the error for a bad executable:

```
scrub-otp-release.sh: ERROR: Unexpected executable format for 'curl'

Got:
 file:Mach-O 64-bit executable x86_64

Expecting:
 readelf:ARM;0x5000200, Version5 EABI, soft-float ABI
```
Here's a sample of the error for a bad library:

```
scrub-otp-release.sh: ERROR: Unexpected executable format for '/circuits_i2c-0.1.0/priv/i2c_nif.so'

Got:
 file:Mach-O 64-bit dynamically linked shared library x86_64

Expecting:
 readelf:ARM;0x5000200, Version5 EABI, soft-float ABI
```

This should fix the reports of webengine_kiosk not working and it also
fixes a particularly nasty bug where a bad .so can fail a boot even when
the library that loads it isn't in the main Shoehorn list.