### PR TITLE
nbtty: bump to v0.4.1

### DIFF
--- a/package/nbtty/nbtty.hash
+++ b/package/nbtty/nbtty.hash
@@ -1,2 +1,2 @@
 # Locally computed:
-sha256  f409f0375b14eebe1d43e554027abd78cffab441190df3eaa2f6ad004e971c0b  nbtty-v0.4.0.tar.gz
+sha256  fbcfc4be6664f4e82f9b9688182eaaf7d4ac72bf3a60e1494e9e65b0bb2f7778  nbtty-v0.4.1.tar.gz

--- a/package/nbtty/nbtty.mk
+++ b/package/nbtty/nbtty.mk
@@ -4,15 +4,10 @@
 #
 ################################################################################
 
-NBTTY_VERSION = v0.4.0
+NBTTY_VERSION = v0.4.1
 NBTTY_SITE = $(call github,fhunleth,nbtty,$(NBTTY_VERSION))
 NBTTY_LICENSE = GPL-2.0+
 NBTTY_LICENSE_FILES = COPYING
 NBTTY_AUTORECONF = YES
-
-# The Makefile does not have an install target.
-define NBTTY_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/nbtty $(TARGET_DIR)/usr/bin/nbtty
-endef
 
 $(eval $(autotools-package))


### PR DESCRIPTION
This adds an option to disable output to the tty until the user presses
the enter key. This reduces I/O when no one is paying attention and can
remove the random output on the USB gadget tty on initial connect.