### PR TITLE
Scrupt Powershell scripts and .script files

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -48,9 +48,11 @@ find "$RELEASE_DIR" -maxdepth 1 -type f -delete
 # Clean up the releases directory
 find "$RELEASE_DIR/releases" \( -name "*.sh" \
                                  -o -name "*.bat" \
+                                 -o -name "*.ps1" \
                                  -o -name "*gz" \
                                  -o -name "start.boot" \
                                  -o -name "start_clean.boot" \
+                                 -o -name "*.script" \
                                  \) -delete
 
 #


### PR DESCRIPTION
Since the scrubber rules were last edited, Windows Powershell scripts
started being generated. Those are obviously not useful for Nerves so
delete them. Also remove the .script files that are the source for the
.boot files.

On a simple project this seems to save ~50 KB compressed and ~25 extra
files.