### PR TITLE
boardid: v1.3.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 842e6acd32b9ad06e194f6d6c805065a1ba403c65f500780eddd3901aa93449a  boardid-v1.2.0.tar.gz
+sha256 b0ee6533c80a6cb8e87f6e035eccf6df551396eadeb5b60205f54b067603a2f4  boardid-v1.3.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.2.0
+BOARDID_VERSION = v1.3.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release improves ATECC508A support and adds an option to force the
ID when all other options fail. I'm using this in manufacturing to make
it easy to connect to unprovisioned devices.