### PR TITLE
boardid: bump to v1.4.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 b0ee6533c80a6cb8e87f6e035eccf6df551396eadeb5b60205f54b067603a2f4  boardid-v1.3.0.tar.gz
+sha256 2e8a0d3cb69ce9a95145c433a290f0b9f20a09f32f93efb8c6972169a4f70946  boardid-v1.4.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.3.0
+BOARDID_VERSION = v1.4.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This adds support for reading a NervesKey serial number from the OTP
memory in it. This serial number is programmed at manufacture time and
can't be modified.