### PR TITLE
boardid: bump to v1.5.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 2e8a0d3cb69ce9a95145c433a290f0b9f20a09f32f93efb8c6972169a4f70946  boardid-v1.4.0.tar.gz
+sha256 8a3331c8c6486270185ef3a010b581caa0ebabfb9a86e03948279dbbbd588455  boardid-v1.5.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.4.0
+BOARDID_VERSION = v1.5.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This add supports for reading boardid options from /etc/boardid.config
rather than having to copy them around in the erlinit.config. It is
backwards compatible and requires no changes to existing Nerves systems.