### PR TITLE
erlinit: v1.4.9

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 a53570069357f1368ec2badc27b1b97636b223229df5ee6520e13b8bb8eb7ef0  erlinit-v1.4.8.tar.gz
+sha256 442597075ab7bead95fa45fa261bbc422e837baa9e30d75323e375bdbf7ef6a9  erlinit-v1.4.9.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.4.8
+ERLINIT_VERSION = v1.4.9
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This fixes an issue that was preventing log messages to be recorded when
verbose is enabled due to a rate limiter in the kernel. It also makes it
possible to start Erlang with `run_erl`.