### PR TITLE
Fix advice for using "build_embedded"

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -128,8 +128,7 @@ for EXECUTABLE in $EXECUTABLES; do
             echo
             echo "1. Are you using a path dependency in your mix deps? If so, run"
             echo "   'mix clean' in that directory to avoid pulling in any of its"
-            echo "   build products. Consider adding 'build_embedded: true' to your"
-            echo "   mix.exs to keep host and target build products separate."
+            echo "   build products."
             echo
             echo "2. Did you recently upgrade to Nerves 1.3 or Distillery 2.0? Make"
             echo "   sure that your 'rel/config.exs' has 'plugin Nerves'. See"


### PR DESCRIPTION
This doesn't work. Path dependencies always build and put their build
products in their directory, so you always have to "mix clean" on those
when switching devices.