### PR TITLE
erlang: bump to 21.2.4

### DIFF
--- a/patches/buildroot/0012-erlang-bump-to-21.2.4.patch
+++ b/patches/buildroot/0012-erlang-bump-to-21.2.4.patch
@@ -1,7 +1,7 @@
-From 7e8cffb62ae302ea5856761875e1929c7c81bb31 Mon Sep 17 00:00:00 2001
+From 0b8b3513ab3a3efc848b7ed9f8bfc0f4440d052c Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:32:11 -0400
-Subject: [PATCH] erlang: bump to 21.2.2
+Subject: [PATCH] erlang: bump to 21.2.4
 
 ---
  ...truct-libatomic_ops-we-do-require-CA.patch | 70 -------------------
@@ -16,9 +16,9 @@ Subject: [PATCH] erlang: bump to 21.2.2
  delete mode 100644 package/erlang/21.0/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
  delete mode 100644 package/erlang/21.0/0002-erts-emulator-reorder-inclued-headers-paths.patch
  delete mode 100644 package/erlang/21.0/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
- create mode 100644 package/erlang/21.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/21.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/21.2.2/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+ create mode 100644 package/erlang/21.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/21.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/21.2.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
 
 diff --git a/package/erlang/21.0/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.0/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -196,11 +196,11 @@ index ad0bb6b453..0000000000
 --- 
 -2.14.1
 -
-diff --git a/package/erlang/21.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/21.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..8e401430fe
 --- /dev/null
-+++ b/package/erlang/21.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/21.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,70 @@
 +From 439fa2eae78a8900bda120072335be19d626498c Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -272,11 +272,11 @@ index 0000000000..8e401430fe
 +-- 
 +1.9.1
 +
-diff --git a/package/erlang/21.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/21.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/21.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/21.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7a6e469dff
 --- /dev/null
-+++ b/package/erlang/21.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/21.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,46 @@
 +From 85a3e5b4f65e5284e59dcdd90e92ea7d50ef6907 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -324,11 +324,11 @@ index 0000000000..7a6e469dff
 + 
 + $(OBJDIR)/%.o: $(TARGET)/%.c
 + 	$(V_CC) $(CFLAGS) $(INCLUDES) -Idrivers/common -c $< -o $@
-diff --git a/package/erlang/21.2.2/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch b/package/erlang/21.2.2/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
+diff --git a/package/erlang/21.2.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch b/package/erlang/21.2.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
 new file mode 100644
 index 0000000000..ad0bb6b453
 --- /dev/null
-+++ b/package/erlang/21.2.2/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
++++ b/package/erlang/21.2.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
 @@ -0,0 +1,42 @@
 +From 011752ec7b31e3dde376270fc65c7ee70644f6e7 Mon Sep 17 00:00:00 2001
 +From: Johan Oudinet <johan.oudinet@gmail.com>
@@ -373,17 +373,17 @@ index 0000000000..ad0bb6b453
 +2.14.1
 +
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 0587c9df01..bb767e0b1a 100644
+index 0587c9df01..4d691bf8a4 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,4 @@
  # sha256 locally computed
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  OTP-21.0.tar.gz
-+sha256 41b1c3a8343218157a683776e71d80a05ac4eb4019a90a760846608d78817690  OTP-21.2.2.tar.gz
++sha256 833d31ac102536b752e474dc6d69be7cc3e37d2d944191317312b30b1ea8ef0d  OTP-21.2.4.tar.gz
  sha256 a06d68aaf4884752d226410ff66547783c260bf4fc92147d60c4011465c1de24  OTP-20.3.8.5.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 2a373688f1..4e2906b122 100644
+index 2a373688f1..22134897ec 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -8,7 +8,7 @@
@@ -391,7 +391,7 @@ index 2a373688f1..4e2906b122 100644
  ERLANG_VERSION = 20.3.8.5
  else
 -ERLANG_VERSION = 21.0
-+ERLANG_VERSION = 21.2.2
++ERLANG_VERSION = 21.2.4
  endif
  
  ERLANG_SITE = https://github.com/erlang/otp/archive


### PR DESCRIPTION
See http://erlang.org/download/OTP-21.2.3.README and
http://erlang.org/download/OTP-21.2.4.README for fixes.