### PR TITLE
Fix OTP minor version detection for asdf

### DIFF
--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -20,6 +20,12 @@ ldlibrarypathadd() {
     fi
 }
 
+clean_erl_output() {
+    tmp=${1//\"}             # Trim double quotes
+    tmp=${tmp//[[:space:]]/} # Trim whitespace
+    echo "$tmp"
+}
+
 if [ -e $NERVES_SYSTEM/host ]; then
     # This is a Linux Buildroot build, so use tools as
     # provided by Buildroot
@@ -131,16 +137,19 @@ export ERL_INTERFACE_INCLUDE_DIR="$ERL_INTERFACE_DIR/include"
 
 # Since it is so important that the host and target Erlang installs
 # match, check it here.
-NERVES_HOST_ERL_MAJOR_VER_RAW=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell)
-NERVES_HOST_ERL_MAJOR_VER=${NERVES_HOST_ERL_MAJOR_VER_RAW//\"}       # Trim double quotes
-NERVES_HOST_ERL_MAJOR_VER=${NERVES_HOST_ERL_MAJOR_VER//[[:space:]]/} # Trim whitespace
 
-# The OTP_VERSION file's location depends on where erl is located. Try both locations
-ERL_DIR=$(dirname "$(command -v erl)")
-HOST_OTP_VERSION_PATH=$ERL_DIR/../lib/erlang/releases/$NERVES_HOST_ERL_MAJOR_VER/OTP_VERSION
-[ -e "$HOST_OTP_VERSION_PATH" ] || HOST_OTP_VERSION_PATH=$ERL_DIR/../../releases/$NERVES_HOST_ERL_MAJOR_VER/OTP_VERSION
+# The OTP_VERSION file's location depends on where erl is located. Ask Erlang for the path
+HOST_OTP_VERSION_PATH=$(erl -eval 'erlang:display(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), halt().' -noshell)
+HOST_OTP_VERSION_PATH=$(clean_erl_output "$HOST_OTP_VERSION_PATH")
+if [ -e "$HOST_OTP_VERSION_PATH" ]; then
+   NERVES_HOST_ERL_VER=$(cat $HOST_OTP_VERSION_PATH)
+else
+   # If no OTP_VERSION file, then use the major number
+   NERVES_HOST_ERL_MAJOR_VER_RAW=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell)
+   NERVES_HOST_ERL_MAJOR_VER=$(clean_erl_output "$NERVES_HOST_ERL_MAJOR_VER_RAW")
+   NERVES_HOST_ERL_VER=$NERVES_HOST_ERL_MAJOR_VER
+fi
 
-NERVES_HOST_ERL_VER=$(cat $HOST_OTP_VERSION_PATH)
 NERVES_TARGET_ERL_VER=$(cat $NERVES_SDK_SYSROOT/usr/lib/erlang/releases/*/OTP_VERSION)
 NERVES_TARGET_ERL_MAJOR_VER=${NERVES_TARGET_ERL_VER%%.*}
 if [ "$NERVES_HOST_ERL_MAJOR_VER" != "$NERVES_TARGET_ERL_MAJOR_VER" ]; then


### PR DESCRIPTION
The asdf shims break the logic for figuring out the OTP minor version.
This change fixes it by determining the path to the OTP_VERSION file
inside of Erlang. If that fails, then fall back to just using the major
number of telling the user that the minor versions might be different.