### PR TITLE
Move build tmp dir to _build

### DIFF
--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -86,7 +86,7 @@ if [[ ! -e "$MKSQUASHFS" ]]; then
     exit 1
 fi
 
-TMP_DIR=$BASE_DIR/_nerves-tmp
+TMP_DIR=$BASE_DIR/_build/_nerves-tmp
 rm -fr "$TMP_DIR"
 
 # Fill in defaults


### PR DESCRIPTION
There are a couple reasons I think this location should be moved to `_build`. My favorite one would probably be the git surprises that can occur at the same time as calling `mix firmware`.