### PR TITLE
fwup: bump to 1.3.1

### DIFF
--- a/patches/buildroot/0013-fwup-bump-to-v1.3.1.patch
+++ b/patches/buildroot/0013-fwup-bump-to-v1.3.1.patch
@@ -1,24 +1,24 @@
-From c4742e54af0003dd1ecbbc6fd0e2ded61340cde5 Mon Sep 17 00:00:00 2001
+From ac13128daa877bc84552b80e50976612f0785543 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Thu, 4 Oct 2018 23:12:34 -0400
-Subject: [PATCH] fwup: bump to v1.3.0
+Subject: [PATCH] fwup: bump to v1.3.1
 
 ---
  package/fwup/fwup.hash | 2 +-
- package/fwup/fwup.mk   | 2 +-
- 2 files changed, 2 insertions(+), 2 deletions(-)
+ package/fwup/fwup.mk   | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
-index 73bff448de..d8da2eace0 100644
+index 73bff448de..d6e8451512 100644
 --- a/package/fwup/fwup.hash
 +++ b/package/fwup/fwup.hash
 @@ -1,3 +1,3 @@
  # Locally calculated
 -sha256 20302dc96cef88438034e15551e178bb0652c28d99aa7ca5260100cb3bebbc2a  fwup-v1.2.5.tar.gz
-+sha256 768ba1c185a78e1b7cca63b1aae0ce2f8a53bee405d6bd7a4b46978338d252cf  fwup-v1.3.0.tar.gz
++sha256 8bf62b9fa1f791394ca94bb973f0f52b2054c67d93a6c8f65e19e8545be5002f  fwup-v1.3.1.tar.gz
  sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
 diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
-index be0b1d13b8..3184895939 100644
+index be0b1d13b8..79f7b97390 100644
 --- a/package/fwup/fwup.mk
 +++ b/package/fwup/fwup.mk
 @@ -4,7 +4,7 @@
@@ -26,10 +26,18 @@ index be0b1d13b8..3184895939 100644
  ################################################################################
  
 -FWUP_VERSION = v1.2.5
-+FWUP_VERSION = v1.3.0
++FWUP_VERSION = v1.3.1
  FWUP_SITE = $(call github,fhunleth,fwup,$(FWUP_VERSION))
  FWUP_LICENSE = Apache-2.0
  FWUP_LICENSE_FILES = LICENSE
+@@ -12,6 +12,7 @@ FWUP_DEPENDENCIES = host-pkgconf libconfuse libarchive libsodium
+ HOST_FWUP_DEPENDENCIES = host-pkgconf host-libconfuse host-libarchive host-libsodium
+ FWUP_AUTORECONF = YES
+ FWUP_CONF_ENV = ac_cv_path_HELP2MAN=""
++FWUP_CONF_OPTS = --disable-scripts
+ 
+ $(eval $(autotools-package))
+ $(eval $(host-autotools-package))
 -- 
 2.17.1
 


### PR DESCRIPTION
This also removes the `img2fwup` script from being installed to
`/usr/bin`.