### PR TITLE
Support specification of rootfs file order to match load order

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -2,7 +2,7 @@
 
 # Merge an overlay directory into a squashfs
 #
-# Usage: merge-squashfs input.squashfs output.squashfs overlay-dir
+# Usage: merge-squashfs input.squashfs output.squashfs overlay-dir squashfs-priorities
 #
 
 set -e
@@ -145,14 +145,15 @@ readlink_f () {
     fi
 }
 
-if [[ $# -ne 3 ]]; then
-    echo "Usage: merge-squashfs input.squashfs output.squashfs overlay-dir"
+if [[ $# -lt 4 ]]; then
+    echo "Usage: merge-squashfs input.squashfs output.squashfs overlay-dir squashfs_priorities"
     exit 1
 fi
 
 input_squashfs=$(readlink_f "$1")
 output_squashfs=$(readlink_f "$2")
 overlay_dir=$(readlink_f "$3")
+squashfs_priorities=$(readlink_f "$4")
 
 if [[ ! -f $input_squashfs ]]; then
     echo "Can't open $input_squashfs"
@@ -174,7 +175,7 @@ awk '!x[$1]++' pseudofile.in > pseudofile
 
 unsquashfs "$input_squashfs" >/dev/null 2>/dev/null
 cp -Rf "$overlay_dir/." "$workdir/squashfs-root"
-mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -noappend -no-recovery -no-progress
+mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -sort "$squashfs_priorities" -noappend -no-recovery -no-progress
 
 # cleanup
 popd >/dev/null

--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -32,13 +32,13 @@ while getopts ":a:c:f:o:" opt; do
             ROOTFS_ADDITIONS="$ROOTFS_ADDITIONS $OPTARG"
             ;;
         c)
-            FWUP_CONFIG=$OPTARG
+            FWUP_CONFIG="$OPTARG"
             ;;
         f)
-            FW_FILENAME=$OPTARG
+            FW_FILENAME="$OPTARG"
             ;;
         o)
-            IMG_FILENAME=$OPTARG
+            IMG_FILENAME="$OPTARG"
             ;;
         \?)
             echo "$SCRIPT_NAME: ERROR: Invalid option: -$OPTARG"

--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -9,6 +9,15 @@ SCRIPT_NAME=$0
 # Check that we have everything that we need
 [[ -z "$NERVES_SYSTEM" ]] && { echo "$SCRIPT_NAME: Source nerves-env.sh and try again."; exit 1; }
 
+# Initialize this script's temporary directory
+TMP_DIR=$BASE_DIR/_build/_nerves-tmp
+rm -fr "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+function cleanup {
+  rm -fr "$TMP_DIR"
+}
+trap cleanup EXIT
+
 usage() {
     echo "Usage: $SCRIPT_NAME [options] <Release directory>"
     echo
@@ -86,9 +95,6 @@ if [[ ! -e "$MKSQUASHFS" ]]; then
     exit 1
 fi
 
-TMP_DIR=$BASE_DIR/_build/_nerves-tmp
-rm -fr "$TMP_DIR"
-
 # Fill in defaults
 [[ -z "$FW_FILENAME" ]] && FW_FILENAME=${PROJECT_DIR}.fw
 [[ -z "$FWUP_CONFIG" ]] && FWUP_CONFIG=$NERVES_SDK_IMAGES/fwup.conf
@@ -108,9 +114,6 @@ mkdir -p "$(dirname "$FW_FILENAME")"
 
 # Update the file system bundle
 echo "Updating base firmware image with Erlang release..."
-
-# Create the directory for all of the files that "overlay" the base squashfs
-mkdir -p "$TMP_DIR/rootfs-additions"
 
 # Construct the proper path for the Erlang/OTP release
 mkdir -p "$TMP_DIR/rootfs-additions/srv/erlang"
@@ -157,5 +160,3 @@ if [[ ! -z "$IMG_FILENAME" ]]; then
     $FWUP -a -d "$IMG_FILENAME" -t complete -i "$FW_FILENAME"
 fi
 
-# Clean up
-rm -fr "$TMP_DIR"


### PR DESCRIPTION
On systems with slow I/O, making the file layout match the load order can improve boot performance. Since squashfs is compressed and `.beam` files are small, multiple `.beam`'s can be loaded in one read and cached by Linux.

This requires a corresponding change to `nerves` to specify a file order (based on the OTP load scripts) to do anything.