### PR TITLE
erlang: enable deterministic build flag

### DIFF
--- a/patches/buildroot/0015-erlang-enable-deterministic-compile-flag.patch
+++ b/patches/buildroot/0015-erlang-enable-deterministic-compile-flag.patch
@@ -1,0 +1,48 @@
+From c7840d8ae8d78f92a28853221b7413f082d95a02 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 21 Mar 2019 20:55:13 -0400
+Subject: [PATCH] erlang: enable deterministic compile flag
+
+Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
+---
+ ...4-erlang-enable-deterministic-builds.patch | 28 +++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+ create mode 100644 package/erlang/21.2.7/0004-erlang-enable-deterministic-builds.patch
+
+diff --git a/package/erlang/21.2.7/0004-erlang-enable-deterministic-builds.patch b/package/erlang/21.2.7/0004-erlang-enable-deterministic-builds.patch
+new file mode 100644
+index 0000000000..1a7e66eca5
+--- /dev/null
++++ b/package/erlang/21.2.7/0004-erlang-enable-deterministic-builds.patch
+@@ -0,0 +1,28 @@
++From 3e357a561042db278d77a6da04623af5e238cecc Mon Sep 17 00:00:00 2001
++From: Frank Hunleth <fhunleth@troodon-software.com>
++Date: Thu, 21 Mar 2019 20:49:54 -0400
++Subject: [PATCH] erlang: enable deterministic builds
++
++This adds the `+deterministic` compiler flag to the `erlc` calls to
++strip out absolute paths in compiled `.beam` files.
++
++Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
++---
++ make/otp.mk.in | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/make/otp.mk.in b/make/otp.mk.in
++index fb573680c8..24acd87549 100644
++--- a/make/otp.mk.in
+++++ b/make/otp.mk.in
++@@ -108,6 +108,7 @@ ifdef BOOTSTRAP
++ else
++   ERL_COMPILE_FLAGS += +debug_info
++ endif
+++ERL_COMPILE_FLAGS += +deterministic
++ ERLC_WFLAGS = -W
++ ERLC = erlc $(ERLC_WFLAGS) $(ERLC_FLAGS)
++ ERL = erl -boot start_clean
++-- 
++2.17.1
++
+-- 
+2.17.1
+


### PR DESCRIPTION
This makes builds slightly more deterministic by removing many absolute paths from the core Erlang libraries. (Saves 60KB after compression in helloworld app)

From the Erlang compiler docs:

>Omit the options and source tuples in the list returned by Module:module_info(compile), and reduce the paths in stack traces to the module name alone. This option will make it easier to achieve reproducible builds. 

Before:

```elixir
iex> :kernel.module_info()
[
  module: :kernel,
  exports: [
    start: 2,
    stop: 1,
    config_change: 3,
    init: 1,
    module_info: 0,
    module_info: 1
  ],
  attributes: [
    vsn: [224767665711555302789215303007070581728],
    behaviour: [:supervisor]
  ],
  compile: [
    version: '7.3.1',
    options: [
      :debug_info,
      {:i,
       '/home/fhunleth/nerves/nerves_system_br/o/rpi0/build/erlang-21.2.7/lib/kernel/src/../include'}
    ],
    source: '/home/fhunleth/nerves/nerves_system_br/o/rpi0/build/erlang-21.2.7/lib/kernel/src/kernel.erl'
  ],
  md5: <<169, 24, 173, 131, 205, 86, 120, 107, 85, 30, 102, 219, 226, 119, 243,
    224>>
]
```

After: 

```elixir
iex> :kernel.module_info()
[
  module: :kernel,
  exports: [
    start: 2,
    stop: 1,
    config_change: 3,
    init: 1,
    module_info: 0,
    module_info: 1
  ],
  attributes: [
    vsn: [224767665711555302789215303007070581728],
    behaviour: [:supervisor]
  ],
  compile: [version: '7.3.1'],
  md5: <<169, 24, 173, 131, 205, 86, 120, 107, 85, 30, 102, 219, 226, 119, 243,
    224>>
]
```