### PR TITLE
erlang: bump to 22.0.2

### DIFF
--- a/patches/buildroot/0012-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0012-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 7628d199a6d5dc104915c0a3d03d34a8495eaf61 Mon Sep 17 00:00:00 2001
+From fafe77f1ea65dfa1f87f264a0c8d19df1169de2a Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.6/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.6/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.0.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.0.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.0.1/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.0.2/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.0.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.0.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.1/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.0.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.0.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.1/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.0.1/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.0.2/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.0.2/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..aa4f5985a3
 --- /dev/null
-+++ b/package/erlang/22.0.1/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.0.2/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From a622016e59d8b8fa21d9dd15c35a7f48d79444cc Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..7d55b58c05 100644
+index 616c85e9ae..7371761f24 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..7d55b58c05 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 694f133abfca3c7fb8376b223ea484413bcd16b82354f178fba798f37335f163  OTP-22.0.1.tar.gz
++sha256 7a9869f5da85349ef21bd9fbc8feafe1a1f563504a65924ddb542deeb37af7cd  OTP-22.0.2.tar.gz
 +sha256 6d310bd97c1d3ef64771143a5ace522ba5f916d501b277315a315e3760edfd0b  OTP-21.3.6.tar.gz
 +sha256 a06d68aaf4884752d226410ff66547783c260bf4fc92147d60c4011465c1de24  OTP-20.3.8.5.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..1384a690bd 100644
+index 757e483389..cd3a7ad5fa 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..1384a690bd 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.6
 +else
-+ERLANG_VERSION = 22.0.1
++ERLANG_VERSION = 22.0.2
 +endif
 +endif
 +


### PR DESCRIPTION
See release notes at:

http://erlang.org/pipermail/erlang-questions/2019-June/098024.html