### PR TITLE
Add gawk to the docker image

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -70,6 +70,7 @@ RUN dpkg --add-architecture i386 \
     squashfs-tools \
     gnupg \
     libmnl-dev \
+    gawk \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \


### PR DESCRIPTION
The latest version of buildroot seems to require gawk to be present on the host