### PR TITLE
erlang: bump to 22.0.7

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 7cdd4c3c80dd433aa63974e19e0656b946d43fc1 Mon Sep 17 00:00:00 2001
+From 44b31acdbbcfd9cce385dc0ca6560c51d16450f3 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.0.5/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.0.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.0.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.5/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.0.5/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..aa4f5985a3
 --- /dev/null
-+++ b/package/erlang/22.0.5/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From a622016e59d8b8fa21d9dd15c35a7f48d79444cc Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..f4aa9f9318 100644
+index 616c85e9ae..e1ec20396a 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..f4aa9f9318 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 28e42e2cf2e43c187f273540987b0f297c46cff2c5eeba453144bc0d41dafd31  OTP-22.0.5.tar.gz
++sha256 04c090b55ec4a01778e7e1a5b7fdf54012548ca72737965b7aa8c4d7878c92bc  OTP-22.0.7.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..a58652f8ed 100644
+index 757e483389..ba83afabb9 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..a58652f8ed 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.0.5
++ERLANG_VERSION = 22.0.7
 +endif
 +endif
 +

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.0.4-1
+ENV ERLANG_OTP_VERSION=22.0.7-1
 ENV FWUP_VERSION=1.3.1
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
Erlang/OTP 22.0.7 release announcement:
http://erlang.org/pipermail/erlang-questions/2019-July/098183.html

Erlang/OTP 22.0.6 release announcement:
http://erlang.org/pipermail/erlang-questions/2019-July/098173.html