### PR TITLE
Add jq to the Dockerfile

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -71,6 +71,7 @@ RUN dpkg --add-architecture i386 \
     gnupg \
     libmnl-dev \
     gawk \
+    jq \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \


### PR DESCRIPTION
`jq` is used a lot in system builds. This adds it to the image that we use on CI.