### PR TITLE
rpi-firmware: bump to 38e81f2

### DIFF
--- a/patches/buildroot/0017-rpi-firmware-support-kernel-selection.patch
+++ b/patches/buildroot/0017-rpi-firmware-support-kernel-selection.patch
@@ -1,4 +1,4 @@
-From dee132cded62a7afd72569f6d168804cb55b6f2b Mon Sep 17 00:00:00 2001
+From c6a796e16516fd620336159697f1f1f686c50ba8 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Mon, 8 Jul 2019 10:44:12 -0400
 Subject: [PATCH] rpi-firmware: support kernel selection
@@ -44,17 +44,17 @@ index aeac6ece95..e2d252574d 100644
  	bool "Firmware to boot"
  	default BR2_PACKAGE_RPI_FIRMWARE_DEFAULT
 diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
-index 0d7ce949a2..a828875eb3 100644
+index 0d7ce949a2..885526793a 100644
 --- a/package/rpi-firmware/rpi-firmware.hash
 +++ b/package/rpi-firmware/rpi-firmware.hash
 @@ -1,2 +1,4 @@
  # Locally computed
 -sha256 c82c40cf37fac36160a7f6b9c314506beb942bf113a55d30fa163c56a4f98946 rpi-firmware-bcf40b5c2b94178c7564fb451098d44968e44af5.tar.gz
-+sha256 e78f5590a3327783c8e9381ab095ad0bd9cf0f842a143f86e032dfe0214a7075 rpi-firmware-eaf726835311e536b29d56a8621826ef2e80aaee.tar.gz
++sha256 f72f3c621d95d41c536e977145970c169d1f9fa55921c535d7f0fac1d8889013 rpi-firmware-38e81f25e639d19fc0ce6e67fd39998c340a15d5.tar.gz
 +sha256 f1d631920ed4ae15f368ba7b8b3caa4ed604f5223372cc6debbd39a101eb8d74 rpi-firmware-81cca1a9380c828299e884dba5efd0d4acb39e8d.tar.gz
 +sha256 5edff641f216d2e09c75469dc2e9fc66aff290e212a1cd43ed31c499f99ea055 rpi-firmware-287af2a2be0787a5d45281d1d6183a2161c798d4.tar.gz
 diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
-index 5aae939503..97bc6bcd1a 100644
+index 5aae939503..4498688416 100644
 --- a/package/rpi-firmware/rpi-firmware.mk
 +++ b/package/rpi-firmware/rpi-firmware.mk
 @@ -4,7 +4,18 @@
@@ -70,7 +70,7 @@ index 5aae939503..97bc6bcd1a 100644
 +RPI_FIRMWARE_VERSION = 81cca1a9380c828299e884dba5efd0d4acb39e8d
 +else
 +# Linux 4.19
-+RPI_FIRMWARE_VERSION = eaf726835311e536b29d56a8621826ef2e80aaee
++RPI_FIRMWARE_VERSION = 38e81f25e639d19fc0ce6e67fd39998c340a15d5
 +endif
 +endif
 +


### PR DESCRIPTION
This fixes an error from vc_dispmanx_display_open. See
https://github.com/fhunleth/rpi_fb_capture/issues/2 for details.