### PR TITLE
Dockerfile: add pkg-config and vim-tiny

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -72,6 +72,7 @@ RUN dpkg --add-architecture i386 \
     libmnl-dev \
     gawk \
     jq \
+    pkg-config \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -73,6 +73,7 @@ RUN dpkg --add-architecture i386 \
     gawk \
     jq \
     pkg-config \
+    vim-tiny \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \


### PR DESCRIPTION
pkg-config is useful for vintage_net. I added vim-tiny since not having vi on CircleCI when debugging builds is really annoying.