### PR TITLE
erlinit: bump to v1.5.1

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 af0766759c122e5b0049bd5760db45285e6b6111745f82aa4fac62240b10a6a2  erlinit-v1.5.0.tar.gz
+sha256 c04fa5b7a784653888d62d1232da7aabd6075cdd663ac3bc0e4eed3bb7d0cbef  erlinit-v1.5.1.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.5.0
+ERLINIT_VERSION = v1.5.1
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This fixes an issue where zombie processes could be created faster than
erlinit could clean them up and then erlinit would stop cleaning them
up.