### PR TITLE
Fix ci-build.sh shellcheck warnings

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -19,10 +19,10 @@ export LD_LIBRARY_PATH=
 
 # Run build in a subdirectory so that we're testing out of tree builds
 mkdir -p ci
-cd ci
+cd ci || exit
 
 # Configure platform
-../create-build.sh ../configs/${CI_DEFCONFIG_DIR}/${CI_DEFCONFIG}_defconfig out || exit 1
+../create-build.sh "../configs/${CI_DEFCONFIG_DIR}/${CI_DEFCONFIG}_defconfig" out || exit 1
 
 # Build the SDK
 


### PR DESCRIPTION
```
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/ci-build.sh 

In scripts/ci-build.sh line 22:
cd ci
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In scripts/ci-build.sh line 25:
../create-build.sh ../configs/${CI_DEFCONFIG_DIR}/${CI_DEFCONFIG}_defconfig out || exit 1
                              ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.

```

Fixes these two warnings.