### PR TITLE
Fix mksyslinuxfs shellcheck warnings

### DIFF
--- a/scripts/mksyslinuxfs.sh
+++ b/scripts/mksyslinuxfs.sh
@@ -34,8 +34,8 @@ if [[ ! -f $SYSLINUX ]]; then
 fi
 
 # Create the boot partition and run it through syslinux
-rm -f $BOOTPART
-dd if=/dev/zero of=$BOOTPART count=0 seek=$BOOTSIZE 2>/dev/null
-$MKFS_VFAT -F 12 -n BOOT $BOOTPART >/dev/null
-$SYSLINUX -i $BOOTPART
+rm -f "$BOOTPART"
+dd if=/dev/zero of="$BOOTPART" count=0 seek="$BOOTSIZE" 2>/dev/null
+"$MKFS_VFAT" -F 12 -n BOOT "$BOOTPART" >/dev/null
+"$SYSLINUX" -i "$BOOTPART"
 


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/mksyslinuxfs.sh 

In scripts/mksyslinuxfs.sh line 37:
rm -f $BOOTPART
      ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksyslinuxfs.sh line 38:
dd if=/dev/zero of=$BOOTPART count=0 seek=$BOOTSIZE 2>/dev/null
                   ^-- SC2086: Double quote to prevent globbing and word splitting.
                                          ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksyslinuxfs.sh line 39:
$MKFS_VFAT -F 12 -n BOOT $BOOTPART >/dev/null
                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksyslinuxfs.sh line 40:
$SYSLINUX -i $BOOTPART
             ^-- SC2086: Double quote to prevent globbing and word splitting.

```

Fixes above warnings.