### PR TITLE
Fix mksystem shellcheck warnings

### DIFF
--- a/scripts/mksystem.sh
+++ b/scripts/mksystem.sh
@@ -24,35 +24,35 @@ set -e
 ARCHIVE_NAME=$1
 BR2_EXTERNAL_NERVES_PATH=$PWD/..
 
-if [ -z $ARCHIVE_NAME ]; then
+if [ -z "$ARCHIVE_NAME" ]; then
     echo "ERROR: Please specify an archive name"
     exit 1
 fi
 
 # Check the working directory
-if [ ! -f $PWD/package/pkg-generic.mk ]; then
+if [ ! -f "$PWD/package/pkg-generic.mk" ]; then
     echo "ERROR: mksystem.sh must be run from the buildroot directory"
     exit 1
 fi
 
 # Check BASE_DIR
-if [ -z $BASE_DIR ]; then
+if [ -z "$BASE_DIR" ]; then
     echo "ERROR: BASE_DIR undefined? Script should be called from Buildroot."
     exit 1
 fi
 
-NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= $BASE_DIR/.config | sed -e 's/BR2_DEFCONFIG=".*\/\(.*\)"/\1/')
+NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= "$BASE_DIR/.config" | sed -e 's/BR2_DEFCONFIG=".*\/\(.*\)"/\1/')
 
 WORK_DIR=$BASE_DIR/tmp-system
-rm -fr $WORK_DIR
-mkdir -p $WORK_DIR/$ARCHIVE_NAME
+rm -fr "$WORK_DIR"
+mkdir -p "$WORK_DIR/$ARCHIVE_NAME"
 
 # Save the version to the archive in case we need it for debug
 VERSION=$(cat ../VERSION)
-echo $VERSION >$WORK_DIR/$ARCHIVE_NAME/nerves-system.tag
+echo "$VERSION" >"$WORK_DIR/$ARCHIVE_NAME/nerves-system.tag"
 
 # Add some help text for the curious
-cat << EOT > $WORK_DIR/$ARCHIVE_NAME/README.md
+cat << EOT > "$WORK_DIR/$ARCHIVE_NAME/README.md"
 # Nerves system image
 
 This is an automatically generated archive created by \`nerves_system_br\`. It is
@@ -67,22 +67,22 @@ nerves_system_br: $VERSION
 EOT
 
 # Copy common nerves shell scripts over
-cp $BR2_EXTERNAL_NERVES_PATH/nerves-env.sh $WORK_DIR/$ARCHIVE_NAME
-cp $BR2_EXTERNAL_NERVES_PATH/nerves.mk $WORK_DIR/$ARCHIVE_NAME
-cp -R $BR2_EXTERNAL_NERVES_PATH/scripts $WORK_DIR/$ARCHIVE_NAME
+cp "$BR2_EXTERNAL_NERVES_PATH/nerves-env.sh" "$WORK_DIR/$ARCHIVE_NAME"
+cp "$BR2_EXTERNAL_NERVES_PATH/nerves.mk" "$WORK_DIR/$ARCHIVE_NAME"
+cp -R "$BR2_EXTERNAL_NERVES_PATH/scripts" "$WORK_DIR/$ARCHIVE_NAME"
 
 # Copy the built configuration over
-cp $BASE_DIR/.config $WORK_DIR/$ARCHIVE_NAME
+cp "$BASE_DIR/.config" "$WORK_DIR/$ARCHIVE_NAME"
 
 # Copy the staging and images directories over
-mkdir -p $WORK_DIR/$ARCHIVE_NAME/images $WORK_DIR/$ARCHIVE_NAME/staging
-cp -R $BASE_DIR/images/* $WORK_DIR/$ARCHIVE_NAME/images
-cp -R $BASE_DIR/staging/* $WORK_DIR/$ARCHIVE_NAME/staging
+mkdir -p "$WORK_DIR/$ARCHIVE_NAME/images" "$WORK_DIR/$ARCHIVE_NAME/staging"
+cp -R "$BASE_DIR/images/*" "$WORK_DIR/$ARCHIVE_NAME/images"
+cp -R "$BASE_DIR/staging/*" "$WORK_DIR/$ARCHIVE_NAME/staging"
 
 # Clean up extra files that were copied over and aren't needed
-rm -f $WORK_DIR/$ARCHIVE_NAME/images/*.fw
-rm -f $WORK_DIR/$ARCHIVE_NAME/images/$ARCHIVE_NAME.img
+rm -f "$WORK_DIR/$ARCHIVE_NAME/images/*.fw"
+rm -f "$WORK_DIR/$ARCHIVE_NAME/images/$ARCHIVE_NAME.img"
 
-tar c -z -f $BASE_DIR/$ARCHIVE_NAME.tar.gz -C $WORK_DIR $ARCHIVE_NAME
+tar c -z -f "$BASE_DIR/$ARCHIVE_NAME.tar.gz" -C "$WORK_DIR $ARCHIVE_NAME"
 
-rm -fr $WORK_DIR
+rm -fr "$WORK_DIR"


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/mksystem.sh 

In scripts/mksystem.sh line 27:
if [ -z $ARCHIVE_NAME ]; then
        ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 33:
if [ ! -f $PWD/package/pkg-generic.mk ]; then
          ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 39:
if [ -z $BASE_DIR ]; then
        ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 44:
NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= $BASE_DIR/.config | sed -e 's/BR2_DEFCONFIG=".*\/\(.*\)"/\1/')
                                       ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 47:
rm -fr $WORK_DIR
       ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 48:
mkdir -p $WORK_DIR/$ARCHIVE_NAME
         ^-- SC2086: Double quote to prevent globbing and word splitting.
                   ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 52:
echo $VERSION >$WORK_DIR/$ARCHIVE_NAME/nerves-system.tag
     ^-- SC2086: Double quote to prevent globbing and word splitting.
               ^-- SC2086: Double quote to prevent globbing and word splitting.
                         ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 55:
cat << EOT > $WORK_DIR/$ARCHIVE_NAME/README.md
             ^-- SC2086: Double quote to prevent globbing and word splitting.
                       ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 70:
cp $BR2_EXTERNAL_NERVES_PATH/nerves-env.sh $WORK_DIR/$ARCHIVE_NAME
   ^-- SC2086: Double quote to prevent globbing and word splitting.
                                           ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                     ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 71:
cp $BR2_EXTERNAL_NERVES_PATH/nerves.mk $WORK_DIR/$ARCHIVE_NAME
   ^-- SC2086: Double quote to prevent globbing and word splitting.
                                       ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 72:
cp -R $BR2_EXTERNAL_NERVES_PATH/scripts $WORK_DIR/$ARCHIVE_NAME
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                                        ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 75:
cp $BASE_DIR/.config $WORK_DIR/$ARCHIVE_NAME
   ^-- SC2086: Double quote to prevent globbing and word splitting.
                     ^-- SC2086: Double quote to prevent globbing and word splitting.
                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 78:
mkdir -p $WORK_DIR/$ARCHIVE_NAME/images $WORK_DIR/$ARCHIVE_NAME/staging
         ^-- SC2086: Double quote to prevent globbing and word splitting.
                   ^-- SC2086: Double quote to prevent globbing and word splitting.
                                        ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 79:
cp -R $BASE_DIR/images/* $WORK_DIR/$ARCHIVE_NAME/images
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                         ^-- SC2086: Double quote to prevent globbing and word splitting.
                                   ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 80:
cp -R $BASE_DIR/staging/* $WORK_DIR/$ARCHIVE_NAME/staging
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                          ^-- SC2086: Double quote to prevent globbing and word splitting.
                                    ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 83:
rm -f $WORK_DIR/$ARCHIVE_NAME/images/*.fw
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 84:
rm -f $WORK_DIR/$ARCHIVE_NAME/images/$ARCHIVE_NAME.img
      ^-- SC2086: Double quote to prevent globbing and word splitting.
                ^-- SC2086: Double quote to prevent globbing and word splitting.
                                     ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 86:
tar c -z -f $BASE_DIR/$ARCHIVE_NAME.tar.gz -C $WORK_DIR $ARCHIVE_NAME
            ^-- SC2086: Double quote to prevent globbing and word splitting.
                      ^-- SC2086: Double quote to prevent globbing and word splitting.
                                              ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                        ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/mksystem.sh line 88:
rm -fr $WORK_DIR
       ^-- SC2086: Double quote to prevent globbing and word splitting.
```

Fixes above warnings.