### PR TITLE
Fix rel2fw shellcheck warnings

### DIFF
--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -77,7 +77,7 @@ while getopts "a:c:f:o:p:" opt; do
             ;;
     esac
 done
-shift $(($OPTIND-1))
+shift $((OPTIND-1))
 
 if [[ $# -lt 1 ]]; then
     echo "$SCRIPT_NAME: ERROR: Expecting release directory"


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/rel2fw.sh 

In scripts/rel2fw.sh line 80:
shift $(($OPTIND-1))
         ^-- SC2004: $/${} is unnecessary on arithmetic variables.
```

Fixes above warning.

https://github.com/koalaman/shellcheck/wiki/SC2004