### PR TITLE
Fix scrub-target shellcheck warning

### DIFF
--- a/scripts/scrub-target.sh
+++ b/scripts/scrub-target.sh
@@ -70,5 +70,6 @@ find "$TARGET_DIR/etc" -type d -empty -delete
 find "$TARGET_DIR/usr" -type d -empty -delete
 echo 'If the next line fails, add the following to nerves_defconfig and build clean (sorry):'
 echo '  BR2_ROOTFS_SKELETON_CUSTOM=y'
+# shellcheck disable=SC2016
 echo '  BR2_ROOTFS_SKELETON_CUSTOM_PATH="${BR2_EXTERNAL_NERVES_PATH}/board/nerves-common/skeleton"'
 find "$TARGET_DIR/var" -type d -empty -delete


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/scrub-target.sh 

In scripts/scrub-target.sh line 73:
echo '  BR2_ROOTFS_SKELETON_CUSTOM_PATH="${BR2_EXTERNAL_NERVES_PATH}/board/nerves-common/skeleton"'
     ^-- SC2016: Expressions don't expand in single quotes, use double quotes for that.


```

https://github.com/koalaman/shellcheck/wiki/SC2016