### PR TITLE
Fix shellcheck buildroot-state warnings

### DIFF
--- a/scripts/buildroot-state.sh
+++ b/scripts/buildroot-state.sh
@@ -33,7 +33,7 @@ fi
 # Trust the passed in version
 echo "Buildroot: $BR_VERSION"
 
-pushd $BR_PATCH_DIR >/dev/null
+pushd "$BR_PATCH_DIR" >/dev/null
 
 # Run a SHA256 on all of the patches (in sorted order)
 find . -name "*.patch" | sort | xargs sha256sum


### PR DESCRIPTION
```
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/buildroot-state.sh 

In scripts/buildroot-state.sh line 36:
pushd $BR_PATCH_DIR >/dev/null
      ^-- SC2086: Double quote to prevent globbing and word splitting.
```