### PR TITLE
Fix shellcheck docker-entrypoint warnings

### DIFF
--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -6,12 +6,12 @@ if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0"
   echo "UID: $UID"
   echo "GID: $GID"
 
-  groupadd -o -g $GID nerves
-  useradd -o -g $GID -u $UID -m nerves
+  groupadd -o -g "$GID" nerves
+  useradd -o -g "$GID" -u "$UID" -m nerves
 
   echo "Switching user"
 
-  gosu nerves $@
+  gosu nerves "$@"
 else
   exec "$@"
 fi


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck support/docker/nerves_system_br/docker-entrypoint.sh 

In support/docker/nerves_system_br/docker-entrypoint.sh line 9:
  groupadd -o -g $GID nerves
                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In support/docker/nerves_system_br/docker-entrypoint.sh line 10:
  useradd -o -g $GID -u $UID -m nerves
                ^-- SC2086: Double quote to prevent globbing and word splitting.


In support/docker/nerves_system_br/docker-entrypoint.sh line 14:
  gosu nerves $@
              ^-- SC2068: Double quote array expansions to avoid re-splitting elements.

```