### PR TITLE
Fix shellcheck ci-deploy warnings

### DIFF
--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -38,10 +38,10 @@ fi
 rm -fr artifacts
 mkdir -p artifacts/$ARTIFACT_SUBDIR
 
-WORK_DIR=_build/*/nerves/system
+WORK_DIR="_build/*/nerves/system"
 if [ ! -d "$WORK_DIR" ]; then
-  WORK_DIR=.nerves/artifacts/*
+  WORK_DIR=".nerves/artifacts/*"
 fi
 
-cp $WORK_DIR/${CI_SYSTEM_NAME}.tar.gz artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.tar.gz
-cp $WORK_DIR/images/${CI_SYSTEM_NAME}.fw artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.fw # only one .fw file in images
+cp "$WORK_DIR/${CI_SYSTEM_NAME}.tar.gz" "artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.tar.gz"
+cp "$WORK_DIR/images/${CI_SYSTEM_NAME}.fw" "artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.fw" # only one .fw file in images


### PR DESCRIPTION
```bash
λ  ~/code/nerves/nerves_system_br (master)  $ shellcheck scripts/ci-deploy.sh 

In scripts/ci-deploy.sh line 41:
WORK_DIR=_build/*/nerves/system
         ^-- SC2125: Brace expansions and globs are literal in assignments. Quote it or use an array.


In scripts/ci-deploy.sh line 43:
  WORK_DIR=.nerves/artifacts/*
           ^-- SC2125: Brace expansions and globs are literal in assignments. Quote it or use an array.


In scripts/ci-deploy.sh line 46:
cp $WORK_DIR/${CI_SYSTEM_NAME}.tar.gz artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.tar.gz
   ^-- SC2086: Double quote to prevent globbing and word splitting.
             ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                                 ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                                                   ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/ci-deploy.sh line 47:
cp $WORK_DIR/images/${CI_SYSTEM_NAME}.fw artifacts/$ARTIFACT_SUBDIR/${CI_SYSTEM_NAME}-$BRANCH_OR_TAG.fw # only one .fw file in images
   ^-- SC2086: Double quote to prevent globbing and word splitting.
                    ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                                    ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                                                      ^-- SC2086: Double quote to prevent globbing and word splitting.

```