### PR TITLE
Add python3-distutils to docker image

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -38,6 +38,7 @@ RUN dpkg --add-architecture i386 \
     python-flake8 \
     python-nose2 \
     python-pexpect \
+    python3-distutils \
     rsync \
     subversion \
     unzip \


### PR DESCRIPTION
Fixes build issues resulting in the error 
```
ModuleNotFoundError: No module named 'distutils.sysconfig'
configure: error: Python failed to run; see above error.
```