### PR TITLE
erlang: bump to OTP 22.1

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From b32a871b52f491b2d2c8532f9dd51b623e7666b5 Mon Sep 17 00:00:00 2001
+From 3b4800eb1c2b274b96a3a90ec64d96cd17e34696 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.1/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.0.7/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.1/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.0.7/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,13 +730,13 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.1/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.1/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
-index 0000000000..aa4f5985a3
+index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.0.7/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.1/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
-+From a622016e59d8b8fa21d9dd15c35a7f48d79444cc Mon Sep 17 00:00:00 2001
++From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
 +Date: Thu, 21 Mar 2019 20:49:54 -0400
 +Subject: [PATCH] erlang: enable deterministic builds
@@ -750,13 +750,13 @@ index 0000000000..aa4f5985a3
 + 1 file changed, 1 insertion(+)
 +
 +diff --git a/make/otp.mk.in b/make/otp.mk.in
-+index cdddb90734..3a5ffb21ae 100644
++index 63748c2f2b..c31cbfe971 100644
 +--- a/make/otp.mk.in
 ++++ b/make/otp.mk.in
-+@@ -110,6 +110,7 @@ ifdef BOOTSTRAP
-+ else
-+   ERL_COMPILE_FLAGS += +debug_info
++@@ -114,6 +114,7 @@ ifeq ($(USE_ESOCK),yes)
++ ERL_COMPILE_FLAGS += -DUSE_ESOCK=true
 + endif
++ 
 ++ERL_COMPILE_FLAGS += +deterministic
 + ERLC_WFLAGS = -W
 + ERLC = erlc $(ERLC_WFLAGS) $(ERLC_FLAGS)
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..e1ec20396a 100644
+index 616c85e9ae..2d44a126ba 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..e1ec20396a 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 04c090b55ec4a01778e7e1a5b7fdf54012548ca72737965b7aa8c4d7878c92bc  OTP-22.0.7.tar.gz
++sha256 7b26f64eb6c712968d8477759fc716d64701d41f6325e8a4d0dd9c31de77284a  OTP-22.1.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..ba83afabb9 100644
+index 757e483389..8673c7d777 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..ba83afabb9 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.0.7
++ERLANG_VERSION = 22.1
 +endif
 +endif
 +
@@ -843,7 +843,7 @@ index 757e483389..ba83afabb9 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_EI_VSN = 3.11.3
 +else
-+ERLANG_EI_VSN = 3.12
++ERLANG_EI_VSN = 3.13
 +endif
 +endif
  


### PR DESCRIPTION
[From the release notes]

Erlang/OTP 22.1 is the first service release for the 22 major release
with new features, improvements as well as bugfixes

Potential Incompatibilities

* Mnesia: Transactions with sticky locks could with async_asym
  transactions be committed in the wrong order, since asym transactions
  are spawned on the remote nodes. To fix this bug the communication
  protocol between mnesia nodes had to be updated, thus mnesia will no
  longer be able to connect to nodes earlier than mnesia-4.14 , OTP-19.0.

* Stdlib: Debugging of time-outs in gen_statem has been improved.
  Starting a time-out is now logged in sys:log and sys:trace. Running
  time-outs are visible in server crash logs, and with sys:get_status. Due
  to this system events {start_timer, Action, State} and {insert_timout,
  Event, State} have been added, which may surprise tools that rely on the
  format of these events. New features: The EventContent of a running
  time-out can be updated with {TimeoutType, update, NewEventContent}.
  Running time-outs can be cancelled with {TimeoutType, cancel} which is
  more readable than using Time = infinity.{rel, Name, Vsn, RelApps,
  Opts}.

Highlights

Compiler:

* erlc can now automatically use a compile server to avoid starting an
  Erlang system for each file to be compiled in a multi-file project. See
  the documentation for how to enable it.

Standard libraries:

* SSL: Basic support for TLS 1.3 Client for experimental use. For more
  information see the Standards Compliance chapter of the User's Guide.

* crypto: The Message Authentication Codes (MAC) CMAC, HMAC and Poly1305
  are unified into common functions in the New Crypto API. See the manual
  for CRYPTO. cipher_info/1 functions returns maps with information about
  the hash or cipher in the argument.

For more details see
http://erlang.org/download/otp_src_22.1.readme