### PR TITLE
bborg-overlays: bump the latest git hash

### DIFF
--- a/package/bborg-overlays/bborg-overlays.hash
+++ b/package/bborg-overlays/bborg-overlays.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 912b01d86d972d165e4552a10bfd78aa4387a39258abab9de8a3fde01d393dca  bborg-overlays-f3d81bb934b1be9f532e31101b2e3f54b4488f14.tar.gz
+sha256 b856c5b035c23dbfb7f99e944afd831eedc56bfe005fc81d9d77054038e4a8d8  bborg-overlays-8e155ff1cdb02298d735c8a14dd152a1e884f3d7.tar.gz

--- a/package/bborg-overlays/bborg-overlays.mk
+++ b/package/bborg-overlays/bborg-overlays.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BBORG_OVERLAYS_VERSION = f3d81bb934b1be9f532e31101b2e3f54b4488f14
+BBORG_OVERLAYS_VERSION = 8e155ff1cdb02298d735c8a14dd152a1e884f3d7
 BBORG_OVERLAYS_SITE = $(call github,beagleboard,bb.org-overlays,$(BBORG_OVERLAYS_VERSION))
 BBORG_OVERLAYS_LICENSE = GPLv2
 BBORG_OVERLAYS_DEPENDENCIES = host-dtc


### PR DESCRIPTION
See
https://github.com/beagleboard/bb.org-overlays/compare/f3d81bb934b1be9f532e31101b2e3f54b4488f14...8e155ff1cdb02298d735c8a14dd152a1e884f3d7
for changes.