### PR TITLE
wpa_supplicant: bump version to 2.9; patches

### DIFF
--- a/patches/buildroot/0016-package-wpa_supplicant-security-bump-version-to-2.9.patch
+++ b/patches/buildroot/0016-package-wpa_supplicant-security-bump-version-to-2.9.patch
@@ -1,0 +1,240 @@
+From 18a26cbeeda6174e5d7998b2daf52d22cb46f29e Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd.kuhls@t-online.de>
+Date: Sun, 25 Aug 2019 21:28:43 +0200
+Subject: [PATCH] package/wpa_supplicant: security bump version to 2.9
+
+Fixes https://w1.fi/security/2019-6/
+
+Removed patch applied upstream:
+http://w1.fi/cgit/hostap/commit/?id=f2973fa39d6109f0f34969e91551a98dc340d537
+
+Removed all other upstream patches which are included in this release.
+
+Release notes:
+http://lists.infradead.org/pipermail/hostap/2019-April/039979.html
+http://lists.infradead.org/pipermail/hostap/2019-August/040373.html
+
+Support for the old dbus interface was removed upstream:
+http://w1.fi/cgit/hostap/commit/?id=6a8dee76d4090287c016680c009b1334e01b5fbd
+
+Removed Config.in option, removed _NEW from remaining dbus option,
+select BR2_PACKAGE_DBUS when needed and added Config.in.legacy options.
+
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+---
+ Config.in.legacy                              | 13 ++++++
+ ...pplicant-2.7-fix-undefined-remove-ie.patch | 43 -------------------
+ package/wpa_supplicant/Config.in              | 20 ++++-----
+ package/wpa_supplicant/wpa_supplicant.hash    | 20 +--------
+ package/wpa_supplicant/wpa_supplicant.mk      | 35 ++-------------
+ 5 files changed, 27 insertions(+), 104 deletions(-)
+ delete mode 100644 package/wpa_supplicant/0001-wpa_supplicant-2.7-fix-undefined-remove-ie.patch
+
+diff --git a/Config.in.legacy b/Config.in.legacy
+index 83dce8b3c8..a5dcee8b27 100644
+--- a/Config.in.legacy
++++ b/Config.in.legacy
+@@ -144,6 +144,19 @@ endif
+ 
+ ###############################################################################
+ 
++config BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW
++	bool "new dbus support option in wpa_supplicant was renamed"
++	select BR2_PACKAGE_WPA_SUPPLICANT_DBUS if BR2_TOOLCHAIN_HAS_THREADS
++	select BR2_LEGACY
++	help
++	  The new dbus support option was renamed.
++
++config BR2_PACKAGE_WPA_SUPPLICANT_DBUS_OLD
++	bool "old dbus support in wpa_supplicant was removed"
++	select BR2_LEGACY
++	help
++	  The old dbus support was removed.
++
+ comment "Legacy options removed in 2019.08"
+ 
+ config BR2_TARGET_TS4800_MBRBOOT
+diff --git a/package/wpa_supplicant/0001-wpa_supplicant-2.7-fix-undefined-remove-ie.patch b/package/wpa_supplicant/0001-wpa_supplicant-2.7-fix-undefined-remove-ie.patch
+deleted file mode 100644
+index eb00d9c150..0000000000
+--- a/package/wpa_supplicant/0001-wpa_supplicant-2.7-fix-undefined-remove-ie.patch
++++ /dev/null
+@@ -1,43 +0,0 @@
+-From f2973fa39d6109f0f34969e91551a98dc340d537 Mon Sep 17 00:00:00 2001
+-From: Jouni Malinen <j@w1.fi>
+-Date: Mon, 3 Dec 2018 12:00:26 +0200
+-Subject: FT: Fix CONFIG_IEEE80211X=y build without CONFIG_FILS=y
+-
+-remove_ie() was defined within an ifdef CONFIG_FILS block while it is
+-now needed even without CONFIG_FILS=y. Remove the CONFIG_FILS condition
+-there.
+-
+-Fixes 8c41734e5de1 ("FT: Fix Reassociation Request IEs during FT protocol")
+-Signed-off-by: Jouni Malinen <j@w1.fi>
+-
+-Downloaded from upstream commit
+-http://w1.fi/cgit/hostap/commit/?id=f2973fa39d6109f0f34969e91551a98dc340d537
+-
+-Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+----
+- wpa_supplicant/sme.c | 2 --
+- 1 file changed, 2 deletions(-)
+-
+-diff --git a/wpa_supplicant/sme.c b/wpa_supplicant/sme.c
+-index 39c8069..f77f751 100644
+---- a/wpa_supplicant/sme.c
+-+++ b/wpa_supplicant/sme.c
+-@@ -1386,7 +1386,6 @@ void sme_event_auth(struct wpa_supplicant *wpa_s, union wpa_event_data *data)
+- }
+- 
+- 
+--#ifdef CONFIG_FILS
+- #ifdef CONFIG_IEEE80211R
+- static void remove_ie(u8 *buf, size_t *len, u8 eid)
+- {
+-@@ -1401,7 +1400,6 @@ static void remove_ie(u8 *buf, size_t *len, u8 eid)
+- 	}
+- }
+- #endif /* CONFIG_IEEE80211R */
+--#endif /* CONFIG_FILS */
+- 
+- 
+- void sme_associate(struct wpa_supplicant *wpa_s, enum wpas_mode mode,
+--- 
+-cgit v0.12
+-
+diff --git a/package/wpa_supplicant/Config.in b/package/wpa_supplicant/Config.in
+index 58a074fae8..1594b877c6 100644
+--- a/package/wpa_supplicant/Config.in
++++ b/package/wpa_supplicant/Config.in
+@@ -100,23 +100,19 @@ config BR2_PACKAGE_WPA_SUPPLICANT_PASSPHRASE
+ 	help
+ 	  Install wpa_passphrase command line utility.
+ 
+-config BR2_PACKAGE_WPA_SUPPLICANT_DBUS_OLD
+-	bool "Enable support for old DBus control interface"
+-	depends on BR2_PACKAGE_DBUS
++config BR2_PACKAGE_WPA_SUPPLICANT_DBUS
++	bool "Enable support for the DBus control interface"
++	depends on BR2_TOOLCHAIN_HAS_THREADS # dbus
++	select BR2_PACKAGE_DBUS
+ 	help
+-	  Enable support for old DBus control interface
+-	  (fi.epitest.hostap.WPASupplicant).
++	  Enable support for the DBus control interface.
+ 
+-config BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW
+-	bool "Enable support for new DBus control interface"
+-	depends on BR2_PACKAGE_DBUS
+-	help
+-	  Enable support for new DBus control interface
+-	  (fi.w1.wpa_supplicant1).
++comment "dbus support needs a toolchain w/ threads"
++	depends on !BR2_TOOLCHAIN_HAS_THREADS
+ 
+ config BR2_PACKAGE_WPA_SUPPLICANT_DBUS_INTROSPECTION
+ 	bool "Introspection support"
+-	depends on BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW
++	depends on BR2_PACKAGE_WPA_SUPPLICANT_DBUS
+ 	help
+ 	  Add introspection support for new DBus control interface.
+ 
+diff --git a/package/wpa_supplicant/wpa_supplicant.hash b/package/wpa_supplicant/wpa_supplicant.hash
+index 2da15f7f5d..ff5a2edb34 100644
+--- a/package/wpa_supplicant/wpa_supplicant.hash
++++ b/package/wpa_supplicant/wpa_supplicant.hash
+@@ -1,19 +1,3 @@
+ # Locally calculated
+-sha256  76ea6b06b7a2ea8e6d9eb1a9166166f1656e6d48c7508914f592100c95c73074  wpa_supplicant-2.7.tar.gz
+-sha256  86979655f1c5a9578acbf83e8acdf69a36dcc0966a8819f3b6918530ad3e0c67  0001-OpenSSL-Use-constant-time-operations-for-private-big.patch
+-sha256  5663da175ecc344c90bea8c95ab831ad47a8002ccbb834f6c091705b92e90e71  0002-Add-helper-functions-for-constant-time-operations.patch
+-sha256  e5a6bc9f587351d4495740239ceb0a64958a59b3e875722dcaeb4c93fa517f64  0003-OpenSSL-Use-constant-time-selection-for-crypto_bignu.patch
+-sha256  aa5b722bebbaf175ff89a3653c3d048afe0d0f866989fca6b4c8e882a864392a  0004-EAP-pwd-Use-constant-time-and-memory-access-for-find.patch
+-sha256  bad9eeaeb118f88303a7a718820b3ba03d705e99b6183b3c44556bedf99db423  0005-SAE-Minimize-timing-differences-in-PWE-derivation.patch
+-sha256  ae7be450f652f6f77ad868856ab61ba6cb6d7e768585cf5f9f9f674a66e05b40  0006-SAE-Avoid-branches-in-is_quadratic_residue_blind.patch
+-sha256  86b731c787ca58ac001d20fb769b136e2ca76bf81a8465a8e72c50573cfc4b09  0007-SAE-Mask-timing-of-MODP-groups-22-23-24.patch
+-sha256  ff7305005217a34818dae247886b9fb1b1db781ab31fb5eac9ebdd9cb0d1edfe  0008-SAE-Use-const_time-selection-for-PWE-in-FFC.patch
+-sha256  707057cc0e60fe763350f82135dbe407bc289a4958879c8ff1e9413243a1caa4  0009-SAE-Use-constant-time-operations-in-sae_test_pwd_see.patch
+-sha256  82d8ae4fabfe3674bcb5412befe3a74e40d6485906589c219be72e4fd1e70baa  0010-SAE-Fix-confirm-message-validation-in-error-cases.patch
+-sha256  ff8d6d92ad4b01987be63cdaf67a24d2eba5b3cd654f37664a8a198e501c0e3b  0011-EAP-pwd-server-Verify-received-scalar-and-element.patch
+-sha256  d5ebf4e5a810e9a0c035f9268195c542273998ea70fd58697ee25965094062cc  0012-EAP-pwd-server-Detect-reflection-attacks.patch
+-sha256  7156656498f03b24a0b69a26a59d17a9fcc8e76761f1dabe6d13b4176ffd2ef8  0013-EAP-pwd-client-Verify-received-scalar-and-element.patch
+-sha256  69926854ec2a79dada290f79f04202764c5d6400d232e3a567ebe633a02c1c66  0014-EAP-pwd-Check-element-x-y-coordinates-explicitly.patch
+-sha256	cba82a051a39c48872250b2e85ca8ebc628cfe75a9ccec29f3e994abd4156152  0001-EAP-pwd-server-Fix-reassembly-buffer-handling.patch
+-sha256	dc0e015463e1fd1f230795e1a49ddd1b9d00e726cd9f38846d0f4892d7978162  0003-EAP-pwd-peer-Fix-reassembly-buffer-handling.patch
+-sha256  76eeecd8fc291a71f29189ea20e6a34387b8048a959cbc6a65c41b98194643a2  README
++sha256  fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17  wpa_supplicant-2.9.tar.gz
++sha256  9da5dd0776da266b180b915e460ff75c6ff729aca1196ab396529510f24f3761  README
+diff --git a/package/wpa_supplicant/wpa_supplicant.mk b/package/wpa_supplicant/wpa_supplicant.mk
+index a518ecc217..0a7a5072dc 100644
+--- a/package/wpa_supplicant/wpa_supplicant.mk
++++ b/package/wpa_supplicant/wpa_supplicant.mk
+@@ -4,25 +4,8 @@
+ #
+ ################################################################################
+ 
+-WPA_SUPPLICANT_VERSION = 2.7
++WPA_SUPPLICANT_VERSION = 2.9
+ WPA_SUPPLICANT_SITE = http://w1.fi/releases
+-WPA_SUPPLICANT_PATCH = \
+-	https://w1.fi/security/2019-1/0001-OpenSSL-Use-constant-time-operations-for-private-big.patch \
+-	https://w1.fi/security/2019-1/0002-Add-helper-functions-for-constant-time-operations.patch \
+-	https://w1.fi/security/2019-1/0003-OpenSSL-Use-constant-time-selection-for-crypto_bignu.patch \
+-	https://w1.fi/security/2019-2/0004-EAP-pwd-Use-constant-time-and-memory-access-for-find.patch \
+-	https://w1.fi/security/2019-1/0005-SAE-Minimize-timing-differences-in-PWE-derivation.patch \
+-	https://w1.fi/security/2019-1/0006-SAE-Avoid-branches-in-is_quadratic_residue_blind.patch \
+-	https://w1.fi/security/2019-1/0007-SAE-Mask-timing-of-MODP-groups-22-23-24.patch \
+-	https://w1.fi/security/2019-1/0008-SAE-Use-const_time-selection-for-PWE-in-FFC.patch \
+-	https://w1.fi/security/2019-1/0009-SAE-Use-constant-time-operations-in-sae_test_pwd_see.patch \
+-	https://w1.fi/security/2019-3/0010-SAE-Fix-confirm-message-validation-in-error-cases.patch \
+-	https://w1.fi/security/2019-4/0011-EAP-pwd-server-Verify-received-scalar-and-element.patch \
+-	https://w1.fi/security/2019-4/0012-EAP-pwd-server-Detect-reflection-attacks.patch \
+-	https://w1.fi/security/2019-4/0013-EAP-pwd-client-Verify-received-scalar-and-element.patch \
+-	https://w1.fi/security/2019-4/0014-EAP-pwd-Check-element-x-y-coordinates-explicitly.patch \
+-	https://w1.fi/security/2019-5/0001-EAP-pwd-server-Fix-reassembly-buffer-handling.patch \
+-	https://w1.fi/security/2019-5/0003-EAP-pwd-peer-Fix-reassembly-buffer-handling.patch
+ WPA_SUPPLICANT_LICENSE = BSD-3-Clause
+ WPA_SUPPLICANT_LICENSE_FILES = README
+ WPA_SUPPLICANT_CONFIG = $(WPA_SUPPLICANT_DIR)/wpa_supplicant/.config
+@@ -115,34 +98,24 @@ WPA_SUPPLICANT_CONFIG_DISABLE += CONFIG_EAP_PWD
+ WPA_SUPPLICANT_CONFIG_EDITS += 's/\#\(CONFIG_TLS=\).*/\1internal/'
+ endif
+ 
+-ifeq ($(BR2_PACKAGE_DBUS),y)
++ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_DBUS),y)
+ WPA_SUPPLICANT_DEPENDENCIES += host-pkgconf dbus
+ WPA_SUPPLICANT_MAKE_ENV = \
+ 	PKG_CONFIG_SYSROOT_DIR="$(STAGING_DIR)" \
+ 	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig"
+-
+-ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_DBUS_OLD),y)
+-WPA_SUPPLICANT_CONFIG_ENABLE += CONFIG_CTRL_IFACE_DBUS=
+-define WPA_SUPPLICANT_INSTALL_DBUS_OLD
+-	$(INSTALL) -m 0644 -D \
+-		$(@D)/wpa_supplicant/dbus/$(WPA_SUPPLICANT_DBUS_OLD_SERVICE).service \
+-		$(TARGET_DIR)/usr/share/dbus-1/system-services/$(WPA_SUPPLICANT_DBUS_OLD_SERVICE).service
+-endef
+-endif
+-
+-ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_DBUS_NEW),y)
+ WPA_SUPPLICANT_CONFIG_ENABLE += CONFIG_CTRL_IFACE_DBUS_NEW
+ define WPA_SUPPLICANT_INSTALL_DBUS_NEW
+ 	$(INSTALL) -m 0644 -D \
+ 		$(@D)/wpa_supplicant/dbus/$(WPA_SUPPLICANT_DBUS_NEW_SERVICE).service \
+ 		$(TARGET_DIR)/usr/share/dbus-1/system-services/$(WPA_SUPPLICANT_DBUS_NEW_SERVICE).service
+ endef
+-endif
+ 
+ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_DBUS_INTROSPECTION),y)
+ WPA_SUPPLICANT_CONFIG_ENABLE += CONFIG_CTRL_IFACE_DBUS_INTRO
+ endif
+ 
++else
++WPA_SUPPLICANT_CONFIG_DISABLE += CONFIG_CTRL_IFACE_DBUS_NEW
+ endif
+ 
+ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_DEBUG_SYSLOG),y)
+-- 
+2.17.1
+

--- a/patches/buildroot/0017-package-wpa_supplicant-add-Config.in-option-for-WPA3.patch
+++ b/patches/buildroot/0017-package-wpa_supplicant-add-Config.in-option-for-WPA3.patch
@@ -1,0 +1,65 @@
+From 3acdccf9964020ad385125e1602d5e4171080d85 Mon Sep 17 00:00:00 2001
+From: Sergey Matyukevich <geomatsi@gmail.com>
+Date: Mon, 9 Sep 2019 23:20:32 +0300
+Subject: [PATCH] package/wpa_supplicant: add Config.in option for WPA3 support
+
+New wpa_supplicant v2.9 enables by default WPA3 features in defconfig.
+Meanwhile building those features requires openssl.
+
+This patch adds Config.in option for WPA3 support in wpa_supplicant.
+When this option is selected, libopenssl is also selected and WPA3
+features OWE, SAE, DPP are enabled in wpa_supplicant .config file.
+When this feature is deselected, then all the above WPA3 options
+are disabled.
+
+Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>
+Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
+---
+ package/wpa_supplicant/Config.in         |  7 +++++++
+ package/wpa_supplicant/wpa_supplicant.mk | 12 ++++++++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/package/wpa_supplicant/Config.in b/package/wpa_supplicant/Config.in
+index 1594b877c6..cba7fa07e1 100644
+--- a/package/wpa_supplicant/Config.in
++++ b/package/wpa_supplicant/Config.in
+@@ -81,6 +81,13 @@ config BR2_PACKAGE_WPA_SUPPLICANT_WPS
+ 	help
+ 	  Enable support for Wi-Fi Protected Setup (WPS).
+ 
++config BR2_PACKAGE_WPA_SUPPLICANT_WPA3
++	bool "Enable WPA3 support"
++	select BR2_PACKAGE_OPENSSL
++	select BR2_PACKAGE_OPENSSL_FORCE_LIBOPENSSL
++	help
++	  Enable WPA3 support including OWE, SAE, DPP
++
+ config BR2_PACKAGE_WPA_SUPPLICANT_CLI
+ 	bool "Install wpa_cli binary"
+ 	help
+diff --git a/package/wpa_supplicant/wpa_supplicant.mk b/package/wpa_supplicant/wpa_supplicant.mk
+index 0a7a5072dc..283c006052 100644
+--- a/package/wpa_supplicant/wpa_supplicant.mk
++++ b/package/wpa_supplicant/wpa_supplicant.mk
+@@ -88,6 +88,18 @@ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_WPS),y)
+ WPA_SUPPLICANT_CONFIG_ENABLE += CONFIG_WPS
+ endif
+ 
++ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_WPA3),y)
++WPA_SUPPLICANT_CONFIG_ENABLE += \
++	CONFIG_DPP \
++	CONFIG_SAE \
++	CONFIG_OWE
++else
++WPA_SUPPLICANT_CONFIG_DISABLE += \
++	CONFIG_DPP \
++	CONFIG_SAE \
++	CONFIG_OWE
++endif
++
+ # Try to use openssl if it's already available
+ ifeq ($(BR2_PACKAGE_LIBOPENSSL),y)
+ WPA_SUPPLICANT_DEPENDENCIES += host-pkgconf libopenssl
+-- 
+2.17.1
+

--- a/patches/buildroot/0018-package-wpa_supplicant-fix-AP-mode-settings.patch
+++ b/patches/buildroot/0018-package-wpa_supplicant-fix-AP-mode-settings.patch
@@ -1,0 +1,50 @@
+From 2b6f152a102551a0a8d86b021331937980867952 Mon Sep 17 00:00:00 2001
+From: Sergey Matyukevich <geomatsi@gmail.com>
+Date: Mon, 9 Sep 2019 23:20:34 +0300
+Subject: [PATCH] package/wpa_supplicant: fix AP mode settings
+
+New wpa_supplicant v2.9 enables by default AP, P2P, WIFI_DISPLAY
+features in defconfig. However these features make sense only for
+wpa_supplicant drivers supporting AP mode.
+
+That is why, for consistent configuration, these features should
+be explicitely disabled in wpa_supplicant .config file unless
+they are requested by Config.in options.
+
+Note that at the moment AP support in Buildroot can be enabled
+only for NL80211 driver.
+
+Fixes:
+http://autobuild.buildroot.net/results/d37672374db935ac29953263ec68a2786ee65cc2/
+
+Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>
+Tested-by: Matt Weber <matthew.weber@rockwellcollins.com>
+Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
+---
+ package/wpa_supplicant/wpa_supplicant.mk | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/package/wpa_supplicant/wpa_supplicant.mk b/package/wpa_supplicant/wpa_supplicant.mk
+index 283c006052..9dcebca9bf 100644
+--- a/package/wpa_supplicant/wpa_supplicant.mk
++++ b/package/wpa_supplicant/wpa_supplicant.mk
+@@ -67,10 +67,16 @@ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_AP_SUPPORT),y)
+ WPA_SUPPLICANT_CONFIG_ENABLE += \
+ 	CONFIG_AP \
+ 	CONFIG_P2P
++else
++WPA_SUPPLICANT_CONFIG_DISABLE += \
++	CONFIG_AP \
++	CONFIG_P2P
+ endif
+ 
+ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_WIFI_DISPLAY),y)
+ WPA_SUPPLICANT_CONFIG_ENABLE += CONFIG_WIFI_DISPLAY
++else
++WPA_SUPPLICANT_CONFIG_DISABLE += CONFIG_WIFI_DISPLAY
+ endif
+ 
+ ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_MESH_NETWORKING),y)
+-- 
+2.17.1
+


### PR DESCRIPTION
This brings in upstream patches to advance the wpa_supplicant to v2.9.
This fixes a Linux kernel module crash when using enterprise WiFi on
Raspberry Pi WiFi modules.

```
00:04:07.122 [warn]  ------------[ cut here ]------------

00:04:07.122 [warn]  WARNING: CPU: 2 PID: 319 at drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c:5126 brcmf_cfg80211_set_pmk+0x40/0x50 [brcmfmac]

00:04:07.135 [warn]  Modules linked in: fixed brcmfmac sha256_generic cfg80211 brcmutil snd_bcm2835(C) snd_pcm snd_timer snd bcm2835_v4l2(C) videobuf2_vmalloc videobuf2_memops v4l2_common bcm2835_mmal_vchiq(C) videobuf2_v4l2 videobuf2_common videodev media vc_sm_cma(C) dwc2

00:04:07.135 [warn]  CPU: 2 PID: 319 Comm: wpa_supplicant Tainted: G        WC        4.19.75 #2

00:04:07.259 [warn]  Hardware name: BCM2835

00:04:07.259 [warn]  [<8010e6c4>] (unwind_backtrace) from [<8010afe4>] (show_stack+0x10/0x14)

00:04:07.259 [warn]  [<8010afe4>] (show_stack) from [<805665b4>] (dump_stack+0x88/0xa8)

00:04:07.259 [warn]  [<805665b4>] (dump_stack) from [<80117f30>] (__warn+0xd4/0xf0)

00:04:07.259 [warn]  [<80117f30>] (__warn) from [<80117f8c>] (warn_slowpath_null+0x40/0x48)

00:04:07.259 [warn]  [<80117f8c>] (warn_slowpath_null) from [<7f147f6c>] (brcmf_cfg80211_set_pmk+0x40/0x50 [brcmfmac])

00:04:07.260 [warn]  [<7f147f6c>] (brcmf_cfg80211_set_pmk [brcmfmac]) from [<7f0ff91c>] (nl80211_set_pmk+0x144/0x168 [cfg80211])

00:04:07.260 [warn]  [<7f0ff91c>] (nl80211_set_pmk [cfg80211]) from [<804c5784>] (genl_rcv_msg+0x1cc/0x3d8)

00:04:07.260 [warn]  [<804c5784>] (genl_rcv_msg) from [<804c4a9c>] (netlink_rcv_skb+0xb8/0x110)

00:04:07.260 [warn]  [<804c4a9c>] (netlink_rcv_skb) from [<804c55a8>] (genl_rcv+0x24/0x34)

00:04:07.260 [warn]  [<804c55a8>] (genl_rcv) from [<804c3b70>] (netlink_unicast+0x17c/0x1f8)

00:04:07.260 [warn]  [<804c3b70>] (netlink_unicast) from [<804c41b4>] (netlink_sendmsg+0x1a4/0x390)

00:04:07.261 [warn]  [<804c41b4>] (netlink_sendmsg) from [<804727b0>] (sock_sendmsg+0x14/0x24)

00:04:07.261 [warn]  [<804727b0>] (sock_sendmsg) from [<80472ac0>] (___sys_sendmsg+0x22c/0x240)

00:04:07.261 [warn]  [<80472ac0>] (___sys_sendmsg) from [<80473f9c>] (__sys_sendmsg+0x50/0x8c)

00:04:07.261 [warn]  [<80473f9c>] (__sys_sendmsg) from [<80101000>] (ret_fast_syscall+0x0/0x4c)

00:04:07.261 [warn]  Exception stack(0x91cd9fa8 to 0x91cd9ff0)

00:04:07.261 [warn]  9fa0:                   00d20e50 00d59f68 00000005 7ec28fe4 00000000 00000000

00:04:07.261 [warn]  9fc0: 00d20e50 00d59f68 00d20dd8 00000128 76c67000 00000001 00000004 00000001

00:04:07.262 [warn]  9fe0: 00000070 7ec28f88 76c4c584 76ba5c74

00:04:07.262 [warn]  ---[ end trace d516f0e0f41bc82a ]---
```