### PR TITLE
fwup: bump to v1.4.0

### DIFF
--- a/patches/buildroot/0012-fwup-bump-to-v1.4.0.patch
+++ b/patches/buildroot/0012-fwup-bump-to-v1.4.0.patch
@@ -1,7 +1,7 @@
-From 9baf0bf735d43e2d5505c64ec791ea4c7ba99829 Mon Sep 17 00:00:00 2001
+From 29ae68b8a043fb09449e1f2420c681893d4fc02f Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Thu, 4 Oct 2018 23:12:34 -0400
-Subject: [PATCH] fwup: bump to v1.3.1
+Subject: [PATCH] fwup: bump to v1.4.0
 
 ---
  package/fwup/fwup.hash | 2 +-
@@ -9,16 +9,16 @@ Subject: [PATCH] fwup: bump to v1.3.1
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
-index 337883f9a8..7d754c9d11 100644
+index 337883f9a8..2723e1a602 100644
 --- a/package/fwup/fwup.hash
 +++ b/package/fwup/fwup.hash
 @@ -1,3 +1,3 @@
  # Locally calculated
 -sha256 20302dc96cef88438034e15551e178bb0652c28d99aa7ca5260100cb3bebbc2a  fwup-1.2.5.tar.gz
-+sha256 8bf62b9fa1f791394ca94bb973f0f52b2054c67d93a6c8f65e19e8545be5002f  fwup-1.3.1.tar.gz
++sha256 5f744364b9c4604153f3eb178426db110fecfa7f9b4e396cd58022d88f26e7f1  fwup-1.4.0.tar.gz
  sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
 diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
-index e1e5467765..730167a2d3 100644
+index e1e5467765..a919c31222 100644
 --- a/package/fwup/fwup.mk
 +++ b/package/fwup/fwup.mk
 @@ -4,7 +4,7 @@
@@ -26,7 +26,7 @@ index e1e5467765..730167a2d3 100644
  ################################################################################
  
 -FWUP_VERSION = 1.2.5
-+FWUP_VERSION = 1.3.1
++FWUP_VERSION = 1.4.0
  FWUP_SITE = $(call github,fhunleth,fwup,v$(FWUP_VERSION))
  FWUP_LICENSE = Apache-2.0
  FWUP_LICENSE_FILES = LICENSE

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV ERLANG_OTP_VERSION=22.1.5-1
-ENV FWUP_VERSION=1.3.1
+ENV FWUP_VERSION=1.4.0
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"
 ENV LANG C.UTF-8


### PR DESCRIPTION
fwup v1.4.0 adds support for GPT partitions and makes it much easier to
handle UEFI-only boards.