### PR TITLE
erlang: bump to 22.1.6

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 25044a7cd21b6288498a8b0be6ef5e7b95342ab1 Mon Sep 17 00:00:00 2001
+From 2280b0911ec86316288d20617d3efd4d4559f192 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.1.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.1.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.1.5/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.1.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.1.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.1.6/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.1.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.1.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.1.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.1.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.1.5/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.1.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.1.5/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.1.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.1.6/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.1.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.1.5/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.1.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.1.5/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.1.5/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.1.6/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.1.6/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.1.5/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.1.6/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..8d66fb2131 100644
+index 616c85e9ae..355a58cd5e 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..8d66fb2131 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 b00622ef0ac433bae912cf11cbf06467a057ea710fbda6317ba5d0b10cc2e4b1  OTP-22.1.5.tar.gz
++sha256 7b29813f480ccb68dee81a753af3ea74513d6ed4d138c90648c19ac247dfee57  OTP-22.1.6.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..a72d62a4ba 100644
+index 757e483389..51386ed0b5 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..a72d62a4ba 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.1.5
++ERLANG_VERSION = 22.1.6
 +endif
 +endif
 +


### PR DESCRIPTION
---------------------------------------------------------------------
 --- compiler-7.4.8 --------------------------------------------------
 ---------------------------------------------------------------------

 The compiler-7.4.8 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16219    Application(s): compiler, erts
               Related Id(s): ERL-1076

               The compiler could do an unsafe optimization of
               receives, which would cause a receive to only scan part
               of the message queue.

               This bug fix in the compiler fixes a bug in the socket
               module.

 Full runtime dependencies of compiler-7.4.8: crypto-3.6, erts-9.0,
 hipe-3.12, kernel-4.0, stdlib-2.5

 ---------------------------------------------------------------------
 --- crypto-4.6.2 ----------------------------------------------------
 ---------------------------------------------------------------------

 The crypto-4.6.2 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16242    Application(s): crypto
               Related Id(s): ERL-1078

               The AEAD tag was not previously checked on decrypt with
               chacha20_poly1305

 Full runtime dependencies of crypto-4.6.2: erts-9.0, kernel-5.3,
 stdlib-3.4

 ---------------------------------------------------------------------
 --- erts-10.5.4 -----------------------------------------------------
 ---------------------------------------------------------------------

 The erts-10.5.4 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16219    Application(s): compiler, erts
               Related Id(s): ERL-1076

               The compiler could do an unsafe optimization of
               receives, which would cause a receive to only scan part
               of the message queue.

               This bug fix in the compiler fixes a bug in the socket
               module.

  OTP-16241    Application(s): erts
               Related Id(s): ERL-1076, OTP-16219

               Fix bug where the receive marker used by the runtime to
               do the receive queue optimization could be incorrectly
               set. The symptom of this would be that a message that
               should match in a receive never matches.

               The bug requires the OTP-22 compiler and multiple
               selective receives to trigger. See OTP-16219 for
               details about the bug fix in the compiler.

 Full runtime dependencies of erts-10.5.4: kernel-6.1, sasl-3.3,
 stdlib-3.5

 ---------------------------------------------------------------------
 --- snmp-5.4.3 ------------------------------------------------------
 ---------------------------------------------------------------------

 The snmp-5.4.3 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16228    Application(s): snmp
               Related Id(s): ERIERL-427

               Agent discovery cleanup. If there is no receiver of
               INFORM then #state.reqs in snmpa_net_if keeps on
               growing for DISCOVERY.

 Full runtime dependencies of snmp-5.4.3: crypto-3.3, erts-6.0,
 kernel-3.0, mnesia-4.12, runtime_tools-1.8.14, stdlib-2.5