### PR TITLE
erlinit: bump to v1.5.3

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 b71b6ae1e2ff9fa39315b2dba39ba51e33da2c63935f919a4e6980a1bbd772fa  erlinit-v1.5.2.tar.gz
+sha256 a8249e04782c8dd419caa2b54bfbabd09c2c784c4b6fb1f527e5d534f3b4b43e  erlinit-v1.5.3.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.5.2
+ERLINIT_VERSION = v1.5.3
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This has a fix for making [slave](http://erlang.org/doc/man/slave.html)
work with Nerves.