### PR TITLE
Convert resolv.conf to a relative symlink

### DIFF
--- a/board/nerves-common/skeleton/etc/resolv.conf
+++ b/board/nerves-common/skeleton/etc/resolv.conf
@@ -1,1 +1,1 @@
-/tmp/resolv.conf
+../tmp/resolv.conf


### PR DESCRIPTION
This keeps the symlink pointing inside this package and is consistent
with upstream Buildroot:

https://git.busybox.net/buildroot/tree/system/skeleton/etc/resolv.conf