### PR TITLE
nerves_initramfs: new package

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -34,6 +34,7 @@ source "$BR2_EXTERNAL_NERVES_PATH/package/erlinit/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nbtty/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nerves-config/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nerves_heart/Config.in"
+source "$BR2_EXTERNAL_NERVES_PATH/package/nerves_initramfs/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/ply/Config.in"
 
 # Load user options

--- a/package/nerves_initramfs/Config.in
+++ b/package/nerves_initramfs/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_NERVES_INITRAMFS
+	bool "nerves_initramfs"
+	help
+          An initramfs for early boot handling of Nerves devices
+
+	  https://github.com/fhunleth/nerves_initramfs

--- a/package/nerves_initramfs/nerves_initramfs.hash
+++ b/package/nerves_initramfs/nerves_initramfs.hash
@@ -1,0 +1,2 @@
+# From https://github.com/fhunleth/nerves_initramfs/releases
+sha256 b1268bc2fce3285d2decc3b6a72d0f400d0ff0491a7adb5fc384b91a910a4621  nerves_initramfs-v0.1.2.tar.gz

--- a/package/nerves_initramfs/nerves_initramfs.mk
+++ b/package/nerves_initramfs/nerves_initramfs.mk
@@ -1,0 +1,16 @@
+#############################################################
+#
+# nerves_initramfs
+#
+#############################################################
+
+NERVES_INITRAMFS_VERSION = v0.1.2
+NERVES_INITRAMFS_SITE = https://github.com/fhunleth/nerves_initramfs/releases/download/$(NERVES_INITRAMFS_VERSION)
+NERVES_INITRAMFS_LICENSE = Apache-2.0
+NERVES_INITRAMFS_INSTALL_IMAGES = YES
+
+define NERVES_INITRAMFS_INSTALL_IMAGES_CMDS
+	$(INSTALL) -D -m 644 $(@D)/nerves_initramfs_$(BR2_ARCH) $(BINARIES_DIR)
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
This pulls down a pre-built initramfs for modifying the boot of Nerves
devices. It makes it possible to revert bad builds automatically without
assistance from the primary bootloader (i.e., Raspberry Pi bootloader)
and also to mount the rootfs via the device mapper (like for encrypted
rootfs support). Note that secure key handling is not yet possible in
the pre-built package, but encrypted filesystems are mountable for test
purposes.