### PR TITLE
busybox: add dmesg back

### DIFF
--- a/board/nerves-common/busybox-1.22.config
+++ b/board/nerves-common/busybox-1.22.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.31.1
-# Wed Dec  4 14:47:14 2019
+# Wed Dec  4 20:49:31 2019
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -588,8 +588,8 @@ CONFIG_DEFAULT_DEPMOD_FILE="modules.dep"
 # CONFIG_BLOCKDEV is not set
 # CONFIG_CAL is not set
 # CONFIG_CHRT is not set
-# CONFIG_DMESG is not set
-# CONFIG_FEATURE_DMESG_PRETTY is not set
+CONFIG_DMESG=y
+CONFIG_FEATURE_DMESG_PRETTY=y
 # CONFIG_EJECT is not set
 # CONFIG_FEATURE_EJECT_SCSI is not set
 # CONFIG_FALLOCATE is not set


### PR DESCRIPTION
dmesg was inadvertently removed in
0aae2f404e3fcfe5240e941068eccd91306f8c7a. This adds it back. It's about
3K so it's an insignificant addition.