### PR TITLE
rpi-wifi-firmware: bump to BCM43430 (7.45.98.83), BCM4345

### DIFF
--- a/board/nerves-common/busybox-1.22.config
+++ b/board/nerves-common/busybox-1.22.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.31.1
-# Wed Dec  4 14:47:14 2019
+# Wed Dec  4 20:49:31 2019
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -588,8 +588,8 @@ CONFIG_DEFAULT_DEPMOD_FILE="modules.dep"
 # CONFIG_BLOCKDEV is not set
 # CONFIG_CAL is not set
 # CONFIG_CHRT is not set
-# CONFIG_DMESG is not set
-# CONFIG_FEATURE_DMESG_PRETTY is not set
+CONFIG_DMESG=y
+CONFIG_FEATURE_DMESG_PRETTY=y
 # CONFIG_EJECT is not set
 # CONFIG_FEATURE_EJECT_SCSI is not set
 # CONFIG_FALLOCATE is not set

--- a/patches/buildroot/0016-rpi-wifi-firmware-bump-to-BCM43430-7.45.98.83-BCM434.patch
+++ b/patches/buildroot/0016-rpi-wifi-firmware-bump-to-BCM43430-7.45.98.83-BCM434.patch
@@ -1,0 +1,36 @@
+From 4d8b343f044aadee5e465965010ed511ce693beb Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Wed, 4 Dec 2019 22:02:57 -0500
+Subject: [PATCH] rpi-wifi-firmware: bump to BCM43430 (7.45.98.83), BCM4345
+ (7.45.189)
+
+---
+ package/rpi-wifi-firmware/rpi-wifi-firmware.hash | 2 +-
+ package/rpi-wifi-firmware/rpi-wifi-firmware.mk   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/rpi-wifi-firmware/rpi-wifi-firmware.hash b/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
+index 5de9e0f13f..c1f9494577 100644
+--- a/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
++++ b/package/rpi-wifi-firmware/rpi-wifi-firmware.hash
+@@ -1,3 +1,3 @@
+ # Locally calculated
+-sha256 51a33d23127300dffd6ac088f372b83ab862053f5e4dc7130676ebaaa824e626  rpi-wifi-firmware-688531da4bcf802a814d9cb0c8b6d62e3b8a3327.tar.gz
++sha256 05db087504be2f6bc1d902cca605114c7f9d458be0adb3b8026369357a329f7a  rpi-wifi-firmware-d4f7087ecbc8eff9cb64a4650765697157821d64.tar.gz
+ sha256 b16056fc91b82a0e3e8de8f86c2dac98201aa9dc3cbd33e8d38f1b087fcec30d  LICENCE.broadcom_bcm43xx
+diff --git a/package/rpi-wifi-firmware/rpi-wifi-firmware.mk b/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
+index 9dd1854b9a..6be02509fe 100644
+--- a/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
++++ b/package/rpi-wifi-firmware/rpi-wifi-firmware.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-RPI_WIFI_FIRMWARE_VERSION = 688531da4bcf802a814d9cb0c8b6d62e3b8a3327
++RPI_WIFI_FIRMWARE_VERSION = d4f7087ecbc8eff9cb64a4650765697157821d64
+ RPI_WIFI_FIRMWARE_SITE = $(call github,LibreELEC,brcmfmac_sdio-firmware-rpi,$(RPI_WIFI_FIRMWARE_VERSION))
+ RPI_WIFI_FIRMWARE_LICENSE = PROPRIETARY
+ RPI_WIFI_FIRMWARE_LICENSE_FILES = LICENCE.broadcom_bcm43xx
+-- 
+2.20.1
+


### PR DESCRIPTION
This appears to fix an issue where the wpa_supplicant would report failures
that look like this on an RPi0 W:

```
[  368.263090] brcmfmac: brcmf_cfg80211_stop_ap: SET SSID error (-110)
[  368.265197] brcmfmac: brcmf_cfg80211_stop_ap: BRCMF_C_DOWN error -110
[  368.267254] brcmfmac: brcmf_cfg80211_stop_ap: setting AP mode failed -110
[  368.269238] brcmfmac: brcmf_cfg80211_stop_ap: BRCMF_C_UP error -110
[  368.271064] brcmfmac: brcmf_vif_set_mgmt_ie: vndr ie set error : -110
[  368.272910] brcmfmac: brcmf_vif_set_mgmt_ie: vndr ie set error : -110
[  368.283320] brcmfmac: brcmf_vif_set_mgmt_ie: vndr ie set error : -512
[  368.285377] brcmfmac: brcmf_set_mpc: fail to set mpc
[  368.289559] brcmfmac: brcmf_sdio_read_control: last control frame is being processed.
[  368.300939] brcmfmac: brcmf_sdio_read_control: last control frame is being processed.
```