### PR TITLE
mesa3d: add support for v3d

### DIFF
--- a/patches/buildroot/0017-mesa3d-add-support-for-v3d.patch
+++ b/patches/buildroot/0017-mesa3d-add-support-for-v3d.patch
@@ -1,0 +1,57 @@
+From c15ba833d93bc082962e3427556e540735dc1ac7 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Wed, 2 Oct 2019 21:17:41 -0400
+Subject: [PATCH] mesa3d: add support for v3d
+
+---
+ package/mesa3d/Config.in | 12 ++++++++++++
+ package/mesa3d/mesa3d.mk |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/package/mesa3d/Config.in b/package/mesa3d/Config.in
+index 455091eb9d..5a54a64cd5 100644
+--- a/package/mesa3d/Config.in
++++ b/package/mesa3d/Config.in
+@@ -217,6 +217,18 @@ config BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_TEGRA
+ 	help
+ 	  Adds support for Nvidia Tegra GPUs, requires nouveau.
+ 
++config BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_V3D
++	bool "Gallium v3d driver"
++	depends on BR2_arm || BR2_aarch64
++	select BR2_PACKAGE_MESA3D_GALLIUM_DRIVER
++	select BR2_PACKAGE_MESA3D_GALLIUM_KMSRO
++	select BR2_PACKAGE_LIBDRM_VC4
++	select BR2_PACKAGE_MESA3D_NEEDS_XA
++	select BR2_PACKAGE_MESA3D_OPENGL_EGL
++	help
++	  Driver for Broadcom V3D (rpi4) GPUs.
++	  It requires a vanilla 4.5+ kernel with drm v3d support.
++
+ config BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VC4
+ 	bool "Gallium vc4 driver"
+ 	depends on BR2_arm || BR2_aarch64
+diff --git a/package/mesa3d/mesa3d.mk b/package/mesa3d/mesa3d.mk
+index fff498e777..20f4e7cf68 100644
+--- a/package/mesa3d/mesa3d.mk
++++ b/package/mesa3d/mesa3d.mk
+@@ -83,6 +83,7 @@ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_RADEONSI) += radeonsi
+ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_SVGA)     += svga
+ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_SWRAST)   += swrast
+ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_TEGRA)    += tegra
++MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_V3D)      += v3d
+ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VC4)      += vc4
+ MESA3D_GALLIUM_DRIVERS-$(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VIRGL)    += virgl
+ # DRI Drivers
+@@ -160,6 +161,8 @@ endif
+ 
+ ifeq ($(BR2_PACKAGE_MESA3D_DRI_DRIVER),y)
+ MESA3D_PLATFORMS = drm
++else ifeq ($(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_V3D),y)
++MESA3D_PLATFORMS = drm
+ else ifeq ($(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VC4),y)
+ MESA3D_PLATFORMS = drm
+ else ifeq ($(BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_ETNAVIV),y)
+-- 
+2.20.1
+


### PR DESCRIPTION
This makes it possible to enable the v3d driver for the Raspberry Pi 4.
Video on the RPi4 is still not working for me, but I believe this is
patch is important for others to use. Since v3d support option has to be
enabled in Buildroot for it to alter a build, this is a low risk patch.