### PR TITLE
ply: new package

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -34,6 +34,7 @@ source "$BR2_EXTERNAL_NERVES_PATH/package/erlinit/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nbtty/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nerves-config/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/nerves_heart/Config.in"
+source "$BR2_EXTERNAL_NERVES_PATH/package/ply/Config.in"
 
 # Load user options
 menu "User-provided options"

--- a/package/ply/Config.in
+++ b/package/ply/Config.in
@@ -1,0 +1,8 @@
+config BR2_PACKAGE_PLY
+	bool "ply"
+	depends on BR2_USE_MMU # fork()
+	help
+	  Dynamic Tracing in Linux
+
+	  https://github.com/iovisor/ply
+

--- a/package/ply/ply.hash
+++ b/package/ply/ply.hash
@@ -1,0 +1,3 @@
+# Locally calculated
+sha256 4cc6e292b140cf71616ab0c097b59a0f8d5272f2fe14d008dfd840caef1163b1  ply-aa5b9ac31307ec1acece818be334ef801c802a12.tar.gz
+sha256 d80c9d084ebfb50ea1ed91bfbc2410d6ce542097a32c43b00781b83adcb8c77f  COPYING

--- a/package/ply/ply.mk
+++ b/package/ply/ply.mk
@@ -1,0 +1,20 @@
+################################################################################
+#
+# ply
+#
+################################################################################
+
+PLY_VERSION = aa5b9ac31307ec1acece818be334ef801c802a12
+PLY_SITE = $(call github,iovisor,ply,$(PLY_VERSION))
+PLY_LICENSE = GPL-2.0
+PLY_LICENSE_FILES = COPYING
+PLY_AUTORECONF = YES
+PLY_DEPENDENCIES = linux
+
+# Fix missing m4 directory error from aclocal
+define PLY_PATCH_M4
+	mkdir -p $(@D)/m4
+endef
+PLY_POST_PATCH_HOOKS += PLY_PATCH_M4
+
+$(eval $(autotools-package))


### PR DESCRIPTION
This adds the ply utility for running eBPF programs.

It requires very low level knowledge to run unfortunately, so it's not
something that will be easily accessible. To get it running, I had to:

1. Make sure it was compiled with the correct Linux headers
2. Change the following kernel options:

```
+CONFIG_BPF_SYSCALL=y
-# CONFIG_PERF_EVENTS is not set
+CONFIG_KPROBES=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_FTRACE_SYSCALLS=y
```

3. Mount debugfs at `/sys/kernel/debug`

The directions on the ply site mostly work. For the Raspberry Pi, the
Linux syscall functions start with `sys` and not `SyS` since it doesn't
use syscall wrappers like x86.