### PR TITLE
erlang: bump to 22.2.2

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 8f1d78c3bd1ede88aed686953e03e6a50f1d8e4f Mon Sep 17 00:00:00 2001
+From c23ff218c80a68c00237238418b2226161c3a840 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.1/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.1/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.1/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.1/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.1/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..79d4f7709f 100644
+index 616c85e9ae..e10493ed53 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..79d4f7709f 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 65ab58ce79181895afc66716cc735a0ada4a3b705a525407d7e1d4c5deb95e72  OTP-22.2.1.tar.gz
++sha256 92df7d22239b09f7580572305c862da1fb030a97cef7631ba060ac51fa3864cc  OTP-22.2.2.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..c84aa0c8f4 100644
+index 757e483389..35b4157df5 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..c84aa0c8f4 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.1
++ERLANG_VERSION = 22.2.2
 +endif
 +endif
 +


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.2.2.README for details.

From the release announcement:

```
---------------------------------------------------------------------
 --- crypto-4.6.4 ----------------------------------------------------
 ---------------------------------------------------------------------

 The crypto-4.6.4 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16376    Application(s): crypto, ssh

               Constant time comparisons added.

 Full runtime dependencies of crypto-4.6.4: erts-9.0, kernel-5.3,
 stdlib-3.4

 ---------------------------------------------------------------------
 --- erts-10.6.2 -----------------------------------------------------
 ---------------------------------------------------------------------

 Note! The erts-10.6.2 application *cannot* be applied independently
       of other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- kernel-6.5.1 (first satisfied in OTP 22.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16371    Application(s): erts

               Taking a scheduler offline could cause timers set while
               executing on that scheduler to be delayed until the
               scheduler was put online again. This bug was introduced
               in ERTS version 10.0 (OTP 21.0).

  OTP-16378    Application(s): erts, stdlib
               Related Id(s): ERL-1125

               The ets:update_counter/4 core dumped when given an
               ordered_set with write_concurrency enabled and an
               invalid position. This bug has been fixed.

  OTP-16379    Application(s): erts

               A process calling erlang:system_flag(multi_scheduling,
               block) could end up blocked waiting for the operation
               to complete indefinitely.

 --- Improvements and New Features ---

  OTP-16333    Application(s): erts
               Related Id(s): ERL-1104

               Duplicate entries for [socket:]getopt and
               [socket:]setopt in man page.

 Full runtime dependencies of erts-10.6.2: kernel-6.5.1, sasl-3.3,
 stdlib-3.5

 ---------------------------------------------------------------------
 --- ssh-4.8.2 -------------------------------------------------------
 ---------------------------------------------------------------------

 Note! The ssh-4.8.2 application *cannot* be applied independently of
       other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- crypto-4.6.4 (first satisfied in OTP 22.2.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16373    Application(s): ssh

               Fixed that ssh_connection:send could allocate a large
               amount of memory if given an iolist() as input data.

  OTP-16375    Application(s): ssh

               Safe atom conversions.

  OTP-16376    Application(s): crypto, ssh

               Constant time comparisons added.

 Full runtime dependencies of ssh-4.8.2: crypto-4.6.4, erts-9.0,
 kernel-5.3, public_key-1.6.1, stdlib-3.4.1

 ---------------------------------------------------------------------
 --- stdlib-3.11.1 ---------------------------------------------------
 ---------------------------------------------------------------------

 Note! The stdlib-3.11.1 application *cannot* be applied independently
       of other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- erts-10.6.2 (first satisfied in OTP 22.2.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16378    Application(s): erts, stdlib
               Related Id(s): ERL-1125

               The ets:update_counter/4 core dumped when given an
               ordered_set with write_concurrency enabled and an
               invalid position. This bug has been fixed.

 Full runtime dependencies of stdlib-3.11.1: compiler-5.0, crypto-3.3,
 erts-10.6.2, kernel-6.0, sasl-3.0
```