### PR TITLE
boardid: bump to v1.6.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 a1881bdb54f21e18125cfbdcee5cc208d1a07db6e831fc4163ecfb73853e3fff  boardid-v1.5.3.tar.gz
+sha256 f3d1168b572087841a969c285c4784b4ddf6f18c497e7398ce216dec7cb57c66  boardid-v1.6.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.5.3
+BOARDID_VERSION = v1.6.0
 BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This version adds support for getting serial numbers from SMBIOS/DMI on
x86 systems.