### PR TITLE
erlang: bump to 22.2.3

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From c23ff218c80a68c00237238418b2226161c3a840 Mon Sep 17 00:00:00 2001
+From 91e699102c0c4ff8b21d4648c564bfa22184bd69 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.2/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..e10493ed53 100644
+index 616c85e9ae..9010f21165 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..e10493ed53 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 92df7d22239b09f7580572305c862da1fb030a97cef7631ba060ac51fa3864cc  OTP-22.2.2.tar.gz
++sha256 8470fff519d9ffa5defba4e42c3c1e64cd86905313040246d4a6e35799a9e614  OTP-22.2.3.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..35b4157df5 100644
+index 757e483389..b559fabecf 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..35b4157df5 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.2
++ERLANG_VERSION = 22.2.3
 +endif
 +endif
 +

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.2.1-1
+ENV ERLANG_OTP_VERSION=22.2.2-1
 ENV FWUP_VERSION=1.5.1
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.2.3.README for details.

From the release announcement:

```
---------------------------------------------------------------------
 --- compiler-7.5.1 --------------------------------------------------
 ---------------------------------------------------------------------

 The compiler-7.5.1 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16385    Application(s): compiler
               Related Id(s): ERL-1128

               Fixed a bug in the compiler that could cause it to
               reject valid code.

 Full runtime dependencies of compiler-7.5.1: crypto-3.6, erts-9.0,
 hipe-3.12, kernel-4.0, stdlib-2.5

 ---------------------------------------------------------------------
 --- ssl-9.5.2 -------------------------------------------------------
 ---------------------------------------------------------------------

 The ssl-9.5.2 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16388    Application(s): ssl
               Related Id(s): ERL-1130

               Fix the handling of GREASE values sent by web browsers
               when establishing TLS 1.3 connections. This change
               improves handling of GREASE values in various protocol
               elements sent in a TLS 1.3 ClientHello.

  OTP-16396    Application(s): ssl
               Related Id(s): ERL-1118

               Correct DTLS listen emulation, could cause problems
               with opening a new DTLS listen socket for a port
               previously used by a now closed DTLS listen socket.

 Full runtime dependencies of ssl-9.5.2: crypto-4.2, erts-10.0,
 inets-5.10.7, kernel-6.0, public_key-1.5, stdlib-3.5
```