### PR TITLE
edk2: copy shell to $BINARIES_DIR

### DIFF
--- a/package/edk2/edk2.mk
+++ b/package/edk2/edk2.mk
@@ -17,7 +17,7 @@ define EDK2_EXTRACT_CMDS
 endef
 
 define EDK2_INSTALL_IMAGES_CMDS
-	cp $(@D)/MinUefiShell/X64/Shell.efi $(BINARIES_DIR)/efi-part
+	cp $(@D)/MinUefiShell/X64/Shell.efi $(BINARIES_DIR)/shell.efi
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This fixes an issue where the `efi-part` directory hasn't been created
so the shell gets renamed as `efi-part`. Since `shell.efi` doesn't get
put in the root of the EFI system partition anyway, I moved it to the
root of the images directory and scripts can put it where ever makes
sense.