### PR TITLE
boardid: bump to v1.7.0

### DIFF
--- a/package/boardid/Config.in
+++ b/package/boardid/Config.in
@@ -3,4 +3,4 @@ config BR2_PACKAGE_BOARDID
 	help
 	  Print out a platform-specific board serial number
 
-	  https://github.com/fhunleth/boardid
+	  https://github.com/nerves-project/boardid

--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 f3d1168b572087841a969c285c4784b4ddf6f18c497e7398ce216dec7cb57c66  boardid-v1.6.0.tar.gz
+sha256 107bcae1df5a22f2920ce1e8991c6cb59660df7ddfd5de1189ab3856e2c21c49  boardid-v1.7.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,8 +4,8 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.6.0
-BOARDID_SITE = $(call github,fhunleth,boardid,$(BOARDID_VERSION))
+BOARDID_VERSION = v1.7.0
+BOARDID_SITE = $(call github,nerves-project,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE
 


### PR DESCRIPTION
This update pulls in support for hardcoding prefixes to serial numbers.
This is used in scenarios where IDs come from third party sources and
company policies requires some prefix for them to be re-used.