### PR TITLE
rng-tools: make jitterentropy optional

### DIFF
--- a/patches/buildroot/0018-rng-tools-make-jitterentropy-optional.patch
+++ b/patches/buildroot/0018-rng-tools-make-jitterentropy-optional.patch
@@ -1,0 +1,83 @@
+From 6964d81666fa9bf7228b245f5ba688e2321666ec Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 30 Jan 2020 14:55:15 -0500
+Subject: [PATCH] rng-tools: make jitterentropy optional
+
+This fixes warning prints and their associated boot delays on Raspberry
+Pi Zero and other systems. Specifically, the following is printed on the
+console:
+
+```
+JITTER rng fails with code 2
+Failed to init entropy source jitter
+```
+
+See https://bugs.busybox.net/show_bug.cgi?id=12511 for discussion.
+For the official Nerves systems, having Jitterentropy being enabled or
+disabled at compile time is reasonable since it's easy to tell whether
+it's in use at all. For example, it just doesn't work on the Raspberry
+Pi Zero. It does work on the BBB, but there's also hardware
+acceleration, so it's not really necessary (assuming the hwrng is
+trustworthy, but then if it's not, do you trust jitterentropy...).
+---
+ package/rng-tools/Config.in    | 11 ++++++++++-
+ package/rng-tools/rng-tools.mk |  8 +++++++-
+ 2 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/package/rng-tools/Config.in b/package/rng-tools/Config.in
+index 71514260e6..2824e69cb1 100644
+--- a/package/rng-tools/Config.in
++++ b/package/rng-tools/Config.in
+@@ -4,7 +4,6 @@ config BR2_PACKAGE_RNG_TOOLS
+ 	# pthread_setaffinity_np
+ 	depends on BR2_TOOLCHAIN_HAS_THREADS_NPTL
+ 	select BR2_PACKAGE_ARGP_STANDALONE if BR2_TOOLCHAIN_USES_UCLIBC || BR2_TOOLCHAIN_USES_MUSL
+-	select BR2_PACKAGE_JITTERENTROPY_LIBRARY
+ 	# For rdrand & darn ligcrypt is required and it's not obvious to users
+ 	select BR2_PACKAGE_LIBGCRYPT if BR2_i386 || BR2_x86_64 || BR2_powerpc64le
+ 	select BR2_PACKAGE_LIBSYSFS
+@@ -13,5 +12,15 @@ config BR2_PACKAGE_RNG_TOOLS
+ 
+ 	  http://sourceforge.net/projects/gkernel/
+ 
++if BR2_PACKAGE_RNG_TOOLS
++
++config BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY
++        bool "Use the jitterentropy library as a source of entropy"
++	select BR2_PACKAGE_JITTERENTROPY_LIBRARY
++        help
++          If your system already has a HWRNG, then this may not be needed.
++
++endif
++
+ comment "rng-tools needs a toolchain w/ NPTL"
+ 	depends on !BR2_TOOLCHAIN_HAS_THREADS_NPTL
+diff --git a/package/rng-tools/rng-tools.mk b/package/rng-tools/rng-tools.mk
+index fa23b3316f..1d0b3ccac6 100644
+--- a/package/rng-tools/rng-tools.mk
++++ b/package/rng-tools/rng-tools.mk
+@@ -8,7 +8,7 @@ RNG_TOOLS_VERSION = 6.7
+ RNG_TOOLS_SITE = $(call github,nhorman,$(RNG_TOOLS_NAME),v$(RNG_TOOLS_VERSION))
+ RNG_TOOLS_LICENSE = GPL-2.0
+ RNG_TOOLS_LICENSE_FILES = COPYING
+-RNG_TOOLS_DEPENDENCIES = libsysfs jitterentropy-library host-pkgconf
++RNG_TOOLS_DEPENDENCIES = libsysfs host-pkgconf
+ 
+ RNG_TOOLS_AUTORECONF = YES
+ 
+@@ -29,6 +29,12 @@ else
+ RNG_TOOLS_CONF_OPTS += --without-libgcrypt
+ endif
+ 
++ifeq ($(BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY),y)
++RNG_TOOLS_DEPENDENCIES += jitterentropy-library
++else
++RNG_TOOLS_CONF_OPTS += --disable-jitterentropy
++endif
++
+ define RNG_TOOLS_INSTALL_INIT_SYSV
+ 	$(INSTALL) -D -m 755 package/rng-tools/S21rngd \
+ 		$(TARGET_DIR)/etc/init.d/S21rngd
+-- 
+2.20.1
+


### PR DESCRIPTION
This fixes warning prints and their associated boot delays on Raspberry
Pi Zero and other systems. Specifically, the following is printed on the
console:

```
JITTER rng fails with code 2
Failed to init entropy source jitter
```

See https://bugs.busybox.net/show_bug.cgi?id=12511 for discussion.  For
the official Nerves systems, having Jitterentropy being enabled or
disabled at compile time is reasonable since it's easy to tell whether
it's in use at all. For example, it just doesn't work on the Raspberry
Pi Zero. It does work on the BBB, but there's also hardware
acceleration, so it's not really necessary (assuming the hwrng is
trustworthy, but then if it's not, do you trust jitterentropy...).