### PR TITLE
erlang: bump to 22.2.4

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 91e699102c0c4ff8b21d4648c564bfa22184bd69 Mon Sep 17 00:00:00 2001
+From 7121664b7ecdd7b2348fe25b38afd7a85c3b9659 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.3/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..9010f21165 100644
+index 616c85e9ae..f991bff6b5 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..9010f21165 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 8470fff519d9ffa5defba4e42c3c1e64cd86905313040246d4a6e35799a9e614  OTP-22.2.3.tar.gz
++sha256 7aab2285b46462332a7fdad395d4629e6465d5da324cf7e081e8d62fdb5b38f1  OTP-22.2.4.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..b559fabecf 100644
+index 757e483389..92a9902837 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..b559fabecf 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.3
++ERLANG_VERSION = 22.2.4
 +endif
 +endif
 +

--- a/patches/buildroot/0018-rng-tools-make-jitterentropy-optional.patch
+++ b/patches/buildroot/0018-rng-tools-make-jitterentropy-optional.patch
@@ -1,0 +1,83 @@
+From 6964d81666fa9bf7228b245f5ba688e2321666ec Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 30 Jan 2020 14:55:15 -0500
+Subject: [PATCH] rng-tools: make jitterentropy optional
+
+This fixes warning prints and their associated boot delays on Raspberry
+Pi Zero and other systems. Specifically, the following is printed on the
+console:
+
+```
+JITTER rng fails with code 2
+Failed to init entropy source jitter
+```
+
+See https://bugs.busybox.net/show_bug.cgi?id=12511 for discussion.
+For the official Nerves systems, having Jitterentropy being enabled or
+disabled at compile time is reasonable since it's easy to tell whether
+it's in use at all. For example, it just doesn't work on the Raspberry
+Pi Zero. It does work on the BBB, but there's also hardware
+acceleration, so it's not really necessary (assuming the hwrng is
+trustworthy, but then if it's not, do you trust jitterentropy...).
+---
+ package/rng-tools/Config.in    | 11 ++++++++++-
+ package/rng-tools/rng-tools.mk |  8 +++++++-
+ 2 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/package/rng-tools/Config.in b/package/rng-tools/Config.in
+index 71514260e6..2824e69cb1 100644
+--- a/package/rng-tools/Config.in
++++ b/package/rng-tools/Config.in
+@@ -4,7 +4,6 @@ config BR2_PACKAGE_RNG_TOOLS
+ 	# pthread_setaffinity_np
+ 	depends on BR2_TOOLCHAIN_HAS_THREADS_NPTL
+ 	select BR2_PACKAGE_ARGP_STANDALONE if BR2_TOOLCHAIN_USES_UCLIBC || BR2_TOOLCHAIN_USES_MUSL
+-	select BR2_PACKAGE_JITTERENTROPY_LIBRARY
+ 	# For rdrand & darn ligcrypt is required and it's not obvious to users
+ 	select BR2_PACKAGE_LIBGCRYPT if BR2_i386 || BR2_x86_64 || BR2_powerpc64le
+ 	select BR2_PACKAGE_LIBSYSFS
+@@ -13,5 +12,15 @@ config BR2_PACKAGE_RNG_TOOLS
+ 
+ 	  http://sourceforge.net/projects/gkernel/
+ 
++if BR2_PACKAGE_RNG_TOOLS
++
++config BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY
++        bool "Use the jitterentropy library as a source of entropy"
++	select BR2_PACKAGE_JITTERENTROPY_LIBRARY
++        help
++          If your system already has a HWRNG, then this may not be needed.
++
++endif
++
+ comment "rng-tools needs a toolchain w/ NPTL"
+ 	depends on !BR2_TOOLCHAIN_HAS_THREADS_NPTL
+diff --git a/package/rng-tools/rng-tools.mk b/package/rng-tools/rng-tools.mk
+index fa23b3316f..1d0b3ccac6 100644
+--- a/package/rng-tools/rng-tools.mk
++++ b/package/rng-tools/rng-tools.mk
+@@ -8,7 +8,7 @@ RNG_TOOLS_VERSION = 6.7
+ RNG_TOOLS_SITE = $(call github,nhorman,$(RNG_TOOLS_NAME),v$(RNG_TOOLS_VERSION))
+ RNG_TOOLS_LICENSE = GPL-2.0
+ RNG_TOOLS_LICENSE_FILES = COPYING
+-RNG_TOOLS_DEPENDENCIES = libsysfs jitterentropy-library host-pkgconf
++RNG_TOOLS_DEPENDENCIES = libsysfs host-pkgconf
+ 
+ RNG_TOOLS_AUTORECONF = YES
+ 
+@@ -29,6 +29,12 @@ else
+ RNG_TOOLS_CONF_OPTS += --without-libgcrypt
+ endif
+ 
++ifeq ($(BR2_PACKAGE_RNG_TOOLS_JITTERENTROPY),y)
++RNG_TOOLS_DEPENDENCIES += jitterentropy-library
++else
++RNG_TOOLS_CONF_OPTS += --disable-jitterentropy
++endif
++
+ define RNG_TOOLS_INSTALL_INIT_SYSV
+ 	$(INSTALL) -D -m 755 package/rng-tools/S21rngd \
+ 		$(TARGET_DIR)/etc/init.d/S21rngd
+-- 
+2.20.1
+

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.2.2-1
+ENV ERLANG_OTP_VERSION=22.2.4-1
 ENV FWUP_VERSION=1.5.1
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.2.4.README for details.

From the release announcement:

```
---------------------------------------------------------------------
 --- ssl-9.5.3 -------------------------------------------------------
 ---------------------------------------------------------------------

 The ssl-9.5.3 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16413    Application(s): ssl
               Related Id(s): ERL-1136

               Enhance error handling, all ALERTS shall be handled
               gracefully and not cause a crash.

  OTP-16424    Application(s): ssl

               Enhance alert logging, in some places the role
               indication of the alert origin was missing. So the log
               would say undefined instead of client or server.

  OTP-16426    Application(s): ssl
               Related Id(s): ERL-1136

               Two different optimizations did not work together and
               resulted in the possible breakage of connections using
               stream ciphers (that is RC4). Reworked the
               implementation to avoid this.

 Full runtime dependencies of ssl-9.5.3: crypto-4.2, erts-10.0,
 inets-5.10.7, kernel-6.0, public_key-1.5, stdlib-3.5

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
```