### PR TITLE
erlang: bump to 22.2.6

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 7121664b7ecdd7b2348fe25b38afd7a85c3b9659 Mon Sep 17 00:00:00 2001
+From e157152b166e44a5255e6e86db80d981623676ae Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.4/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.4/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..f991bff6b5 100644
+index 616c85e9ae..dfe09fd54f 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..f991bff6b5 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 7aab2285b46462332a7fdad395d4629e6465d5da324cf7e081e8d62fdb5b38f1  OTP-22.2.4.tar.gz
++sha256 4cf44ed12f657c309a2c00e7806f36f56a88e5b74de6814058796561f3842f66  OTP-22.2.6.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..92a9902837 100644
+index 757e483389..e1463b2289 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..92a9902837 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.4
++ERLANG_VERSION = 22.2.6
 +endif
 +endif
 +


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.2.5.README and
https://erlang.org/download/OTP-22.2.6.README for details.

From the release announcements:

```
---------------------------------------------------------------------
 --- erts-10.6.3 -----------------------------------------------------
 ---------------------------------------------------------------------

 Note! The erts-10.6.3 application *cannot* be applied independently
       of other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- kernel-6.5.1 (first satisfied in OTP 22.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16436    Application(s): erts
               Related Id(s): ERL-1152

               A process could end up in a state where it got
               endlessly rescheduled without making any progress. This
               occurred when a system task, such as check of process
               code (part of a code purge), was scheduled on a high
               priority process trying to execute on a dirty
               scheduler.

 --- Improvements and New Features ---

  OTP-16358    Application(s): erts

               Improved signal handling for processes executing dirty.
               For example, avoid busy wait in dirty signal handler
               process when process is doing garbage collection on
               dirty scheduler.

 Full runtime dependencies of erts-10.6.3: kernel-6.5.1, sasl-3.3,
 stdlib-3.5

 ---------------------------------------------------------------------
 --- stdlib-3.11.2 ---------------------------------------------------
 ---------------------------------------------------------------------

 Note! The stdlib-3.11.2 application *cannot* be applied independently
       of other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- erts-10.6.2 (first satisfied in OTP 22.2.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16441    Application(s): stdlib

               A directory traversal vulnerability has been eliminated
               in erl_tar. erl_tar will now refuse to extract symlinks
               that points outside the targeted extraction directory
               and will return {error,{Path,unsafe_symlink}}. (Thanks
               to Eric Meadows-JÃ¶nsson for the bug report and for
               suggesting a fix.)

 Full runtime dependencies of stdlib-3.11.2: compiler-5.0, crypto-3.3,
 erts-10.6.2, kernel-6.0, sasl-3.0

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
```

and

```
---------------------------------------------------------------------
 --- erts-10.6.4 -----------------------------------------------------
 ---------------------------------------------------------------------

 Note! The erts-10.6.4 application *cannot* be applied independently
       of other applications on an arbitrary OTP 22 installation.

       On a full OTP 22 installation, also the following runtime
       dependency has to be satisfied:
       -- kernel-6.5.1 (first satisfied in OTP 22.2)

 --- Fixed Bugs and Malfunctions ---

  OTP-16446    Application(s): erts
               Related Id(s): ERL-1157

               A process could get into an inconsistent state where it
               was runnable, but never scheduled for execution. This
               could occur when a mix of normal and low priority
               processes where scheduled on the same type of dirty
               scheduler simultaneously.

 Full runtime dependencies of erts-10.6.4: kernel-6.5.1, sasl-3.3,
 stdlib-3.5

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
```