### PR TITLE
Apply system-specific buildroot patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,11 @@ will only be stored in your build directory. To make them permanent, save the
 `.config` (see `build/busybox-*/.config`) to your configuration directory. You
 will need to run `make menuconfig` to update the location of the Busybox
 configuration.
+
+### Adding system-specific buildroot patches
+
+A Nerves system can include additional buildroot patches to be applied in the
+the directory `${NERVES_DEFCONFIG_DIR}/patches/buildroot` where
+`NERVES_DEFCONFIG_DIR` is the director to where your defocnfig file exists.
+Any `.patch` file in this directory will be applied after the Nerves-specific
+buildroot patches found in `${NERVES_SYSTEM_BR}/patches/buildroot`.

--- a/create-build.sh
+++ b/create-build.sh
@@ -121,6 +121,11 @@ create_buildroot_dir() {
     # Apply Nerves-specific patches
     "$NERVES_SYSTEM/buildroot/support/scripts/apply-patches.sh" "$NERVES_SYSTEM/buildroot" "$NERVES_SYSTEM/patches/buildroot"
 
+    # Apply system-specific patches if they exist
+    if [ -d $NERVES_DEFCONFIG_DIR/patches/buildroot ]; then
+      "$NERVES_SYSTEM/buildroot/support/scripts/apply-patches.sh" "$NERVES_SYSTEM/buildroot" "$NERVES_DEFCONFIG_DIR/patches/buildroot"
+    fi
+
     # Symlink Buildroot's dl directory so that it can be cached between builds
     ln -sf "$NERVES_BR_DL_DIR" "$NERVES_SYSTEM/buildroot/dl"
 


### PR DESCRIPTION
Apply any buildroot patches located in `$NERVES_DEFCONFIG_DIR/patches/buildroot` if the directory exists. These patches are applied following the nerves patches.