### PR TITLE
boardid: bump to v1.8.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 107bcae1df5a22f2920ce1e8991c6cb59660df7ddfd5de1189ab3856e2c21c49  boardid-v1.7.0.tar.gz
+sha256 8d6c38308f994a7554639b117d7549aa7f48c874b305fa24567b9979a19185ac  boardid-v1.8.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.7.0
+BOARDID_VERSION = v1.8.0
 BOARDID_SITE = $(call github,nerves-project,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This adds support for the nVidia Jetson Nano and similar boards.