### PR TITLE
erlang: bump to 22.2.8

### DIFF
--- a/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0011-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From e157152b166e44a5255e6e86db80d981623676ae Mon Sep 17 00:00:00 2001
+From d559ca13d114bca6309cabae19fb900917aeb840 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -35,9 +35,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -598,11 +598,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.6/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -675,11 +675,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.6/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -730,11 +730,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.6/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -798,7 +798,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 616c85e9ae..dfe09fd54f 100644
+index 616c85e9ae..e93df9f7c8 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -806,12 +806,12 @@ index 616c85e9ae..dfe09fd54f 100644
 -md5 350988f024f88e9839c3715b35e7e27a  otp_src_21.0.tar.gz
 -sha256 c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131  otp_src_21.0.tar.gz
 +# sha256 locally computed
-+sha256 4cf44ed12f657c309a2c00e7806f36f56a88e5b74de6814058796561f3842f66  OTP-22.2.6.tar.gz
++sha256 71f73ddd59db521928a0f6c8d4354d6f4e9f4bfbd0b40d321cd5253a6c79b095  OTP-22.2.8.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 757e483389..e1463b2289 100644
+index 757e483389..eb73f747c8 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -825,7 +825,7 @@ index 757e483389..e1463b2289 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.6
++ERLANG_VERSION = 22.2.8
 +endif
 +endif
 +

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.2.6-1
+ENV ERLANG_OTP_VERSION=22.2.7-1
 ENV FWUP_VERSION=1.5.1
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.2.7.README and
https://erlang.org/download/OTP-22.2.8.README for details.

From the release announcements:

```
---------------------------------------------------------------------
 --- compiler-7.5.2 --------------------------------------------------
 ---------------------------------------------------------------------

 The compiler-7.5.2 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16452    Application(s): compiler
               Related Id(s): ERL-1161

               Fixed a bug that could cause the compiler to reject
               valid code that used the is_map_key/2 BIF.

  OTP-16456    Application(s): compiler
               Related Id(s): ERL-1163

               Fixed a bug that could cause the compiler to reject
               valid code that matched the same map key several times.

  OTP-16466    Application(s): compiler
               Related Id(s): ERL-1170

               The compiler could crash when compiling a convoluted
               receive statement.

  OTP-16467    Application(s): compiler
               Related Id(s): ERL-1166, ERL-1167

               The compiler could crash when a fun was created but
               never used.

               The compiler could crash when compiling the expression
               true = 0 / X.

 Full runtime dependencies of compiler-7.5.2: crypto-3.6, erts-9.0,
 hipe-3.12, kernel-4.0, stdlib-2.5

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
```

and

```
---------------------------------------------------------------------
 --- diameter-2.2.2 --------------------------------------------------
 ---------------------------------------------------------------------

 The diameter-2.2.2 application can be applied independently of other
 applications on a full OTP 22 installation.

 --- Fixed Bugs and Malfunctions ---

  OTP-16457    Application(s): diameter

               The possibility of choosing a handler process for an
               incoming Diameter request with a configured MFA was
               documented in OTP 20.0, but counters (with
               {traffic_counters, true}) were not incremented when
               this process was on a remote node. Counters are now
               incremented on the node that configures the transport
               in question.

               Introduced in OTP 21.3.

  OTP-16459    Application(s): diameter

               Transport options differing from those passed to
               diameter:add_transport/2 were used in several
               situations: when starting a transport process after
               connect_timer expiry after an initial connection
               attempt has failed, when starting a transport process
               after a connection has been accepted, when sending
               events, when returning options in
               diameter:service_info/2, and possibly more. In
               particular, the following configuration options to
               diameter:add_transport/2 were dropped:
               avp_dictionaries, incoming_maxlen, spawn_opt,
               strict_mbit.

               Moreover, any service options mistakenly passed to
               diameter:add_transport/2 were interpreted as such,
               instead of being ignored as the documentation states,
               with the consequence that outgoing and incoming
               requests saw different values of some options, some
               were always taken from transport options, and others
               from service options.

               diameter:add_transport/2 must be called in new code for
               the fix to have effect.

               Introduced in OTP 20.1.

 Full runtime dependencies of diameter-2.2.2: erts-10.0, kernel-3.2,
 ssl-9.0, stdlib-2.4

 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
 ---------------------------------------------------------------------
```