### PR TITLE
rpi-firmware: bump to 1.20200212

### DIFF
--- a/patches/buildroot/0016-rpi-firmware-bump-to-1.20200212.patch
+++ b/patches/buildroot/0016-rpi-firmware-bump-to-1.20200212.patch
@@ -1,0 +1,38 @@
+From 19ac83749896c589bdbd5ef0274086337f205e73 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Mon, 9 Mar 2020 21:29:27 -0400
+Subject: [PATCH] rpi-firmware: bump to 1.20200212
+
+---
+ package/rpi-firmware/rpi-firmware.hash | 4 ++--
+ package/rpi-firmware/rpi-firmware.mk   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
+index 01206f9066..8535904fb7 100644
+--- a/package/rpi-firmware/rpi-firmware.hash
++++ b/package/rpi-firmware/rpi-firmware.hash
+@@ -1,5 +1,5 @@
+ # Locally computed
+-sha256 ec2dbd3cd7654f743894ffb9100e7e86ef9d840e7cf113c0b517e0da42cbbb02 rpi-firmware-1.20190819.tar.gz
++sha256 e3b0577beb62d886a45016447bdf8c2d57b794d3d71b502868b16ba82ff8fe43 rpi-firmware-1.20200212.tar.gz
+ sha256 f1d631920ed4ae15f368ba7b8b3caa4ed604f5223372cc6debbd39a101eb8d74 rpi-firmware-81cca1a9380c828299e884dba5efd0d4acb39e8d.tar.gz
+ sha256 5edff641f216d2e09c75469dc2e9fc66aff290e212a1cd43ed31c499f99ea055 rpi-firmware-287af2a2be0787a5d45281d1d6183a2161c798d4.tar.gz
+-sha256 ba76edfc10a248166d965b8eaf320771c44f4f432d4fce2fd31fd272e7038add boot/LICENCE.broadcom
++sha256 c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b boot/LICENCE.broadcom
+diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
+index e78fd4853d..a2a935f433 100644
+--- a/package/rpi-firmware/rpi-firmware.mk
++++ b/package/rpi-firmware/rpi-firmware.mk
+@@ -12,7 +12,7 @@ ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_KERNEL_4_14),y)
+ RPI_FIRMWARE_VERSION = 81cca1a9380c828299e884dba5efd0d4acb39e8d
+ else
+ # Linux 4.19
+-RPI_FIRMWARE_VERSION = 1.20190819
++RPI_FIRMWARE_VERSION = 1.20200212
+ endif
+ endif
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Bump to the latest released rpi-firmware version so that its at the same
level as the upcoming v1.11.0 nerves_system_rpi* Linux kernel versions.