### PR TITLE
erlang: bump to 22.3

### DIFF
--- a/patches/buildroot/0010-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0010-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 177414d3fbd57f348a0293bb475685184328f6b2 Mon Sep 17 00:00:00 2001
+From 8a182018f102ed1bdbda737444662d1a847584f9 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -22,8 +22,8 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  ...3-erlang-enable-deterministic-builds.patch | 28 ++++++++
  package/erlang/Config.in                      | 22 ++++++
  package/erlang/erlang.hash                    |  7 +-
- package/erlang/erlang.mk                      | 19 ++++-
- 15 files changed, 533 insertions(+), 120 deletions(-)
+ package/erlang/erlang.mk                      | 21 +++++-
+ 15 files changed, 534 insertions(+), 121 deletions(-)
  delete mode 100644 package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
  delete mode 100644 package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/20.3.8.9/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
@@ -33,9 +33,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.3/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -548,11 +548,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.2.8/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -625,11 +625,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.3/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.2.8/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -680,11 +680,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.3/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.3/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.2.8/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.3/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -748,7 +748,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 3c2f039496..e93df9f7c8 100644
+index 3c2f039496..b625e947d0 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -756,12 +756,12 @@ index 3c2f039496..e93df9f7c8 100644
 -md5 b2b48dad6e69c1e882843edbf2abcfd3  otp_src_22.2.tar.gz
 -sha256 89c2480cdac566065577c82704a48e10f89cf2e6ca5ab99e1cf80027784c678f  otp_src_22.2.tar.gz
 +# sha256 locally computed
-+sha256 71f73ddd59db521928a0f6c8d4354d6f4e9f4bfbd0b40d321cd5253a6c79b095  OTP-22.2.8.tar.gz
++sha256 886e6dbe1e4823c7e8d9c9c1ba8315075a1a9f7717f5a1eaf3b98345ca6c798e  OTP-22.3.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 836edf9bce..1e4734e1a5 100644
+index 836edf9bce..a0f7f30e9f 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -775,7 +775,7 @@ index 836edf9bce..1e4734e1a5 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.2.8
++ERLANG_VERSION = 22.3
 +endif
 +endif
 +
@@ -786,13 +786,14 @@ index 836edf9bce..1e4734e1a5 100644
  
  # Whenever updating Erlang, this value should be updated as well, to the
  # value of EI_VSN in the file lib/erl_interface/vsn.mk
+-ERLANG_EI_VSN = 3.13.1
 +ifeq ($(BR2_PACKAGE_ERLANG_20),y)
 +ERLANG_EI_VSN = 3.10.2.1
 +else
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_EI_VSN = 3.11.3
 +else
- ERLANG_EI_VSN = 3.13.1
++ERLANG_EI_VSN = 3.13.2
 +endif
 +endif
  

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.2.8-1
+ENV ERLANG_OTP_VERSION=22.3-1
 ENV FWUP_VERSION=1.5.1
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
See https://erlang.org/download/OTP-22.3.README for details.

Highlights:

```
  OTP-15856    Application(s): ssl

               Implementation of the key and initialization vector
               update feature, and general hardening of TLS 1.3.

               There are cryptographic limits on the amount of
               plaintext which can be safely encrypted under a given
               set of keys.

               This change enforces those limits by triggering
               automatic key updates on TLS 1.3 connections.

  OTP-16253    Application(s): ssl

               Add support for TLS 1.3 Session Tickets (stateful and
               stateless). This allows session resumption using keying
               material from a previous successful handshake.

  OTP-16309    Application(s): erts, sasl

               A socket "registry" has been added making it possible
               to list current open sockets.

  OTP-16485    Application(s): ssh

               The new functions ssh:set_sock_opts/2 and
               ssh:get_sock_opts/2 sets and reads option values for
               the underlying TCP stream.

```