### PR TITLE
erlinit: bump to v1.6.1

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 b06eb346f961284a634ed040e53b1fec37b288cfc27731d9104e58b0cae1732d  erlinit-v1.6.0.tar.gz
+sha256 d8a4248d9ea8cce070ed50fe62f36cfd1d8df0c6fe7c3702300559f10de53e5d  erlinit-v1.6.1.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.6.0
+ERLINIT_VERSION = v1.6.1
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This update fixes an issue with rootdisk symlink creation on a few
platforms. This did not affect any of the officially supported Nerves
systems.