### PR TITLE
Update erlinit project repo url

### DIFF
--- a/package/erlinit/Config.in
+++ b/package/erlinit/Config.in
@@ -4,4 +4,4 @@ config BR2_PACKAGE_ERLINIT
 	help
 	  Erlinit is a replacement for /sbin/init that starts erlang.
 
-	  https://github.com/fhunleth/erlinit
+	  https://github.com/nerves-project/erlinit


### PR DESCRIPTION
I just noticed an out of date repository URL when looking at buildroot integration. 