### PR TITLE
Add NERVES_MKSQUASHFS_FLAGS

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -175,7 +175,7 @@ awk '!x[$1]++' pseudofile.in > pseudofile
 
 unsquashfs "$input_squashfs" >/dev/null 2>/dev/null
 cp -Rf "$overlay_dir/." "$workdir/squashfs-root"
-mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -sort "$squashfs_priorities" -noappend -no-recovery -no-progress
+mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -sort "$squashfs_priorities" -noappend -no-recovery -no-progress $NERVES_MKSQUASHFS_FLAGS
 
 # cleanup
 popd >/dev/null


### PR DESCRIPTION
Additional flags can be passed to mksquashfs by setting `NERVES_MKSQUASHFS_FLAGS`

for example:
`NERVES_MKSQUASHFS_FLAGS="-noD"`

This makes it possible to disable compression on the squashfs output for use with creating patch files. 