### PR TITLE
erlinit: bump to v1.7.0

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 d8a4248d9ea8cce070ed50fe62f36cfd1d8df0c6fe7c3702300559f10de53e5d  erlinit-v1.6.1.tar.gz
+sha256 c9302be17ca165ea1221db05e86f182780e18df189b2b09961408f152605f0c4  erlinit-v1.7.0.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.6.1
+ERLINIT_VERSION = v1.7.0
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This adds support for initializing UARTs. Prior to this version, if the
Linux kernel didn't initialize the UART, it would look like the UART
wasn't working. You could programmatically initialize the UART using
Circuits.UART, but initializing it in `erlinit` is simpler.