### PR TITLE
erlang: bump to 22.3.3

### DIFF
--- a/patches/buildroot/0010-erlang-support-OTP-20-21-and-22.patch
+++ b/patches/buildroot/0010-erlang-support-OTP-20-21-and-22.patch
@@ -1,4 +1,4 @@
-From 3ed1acbe56fd4590ea99477682fd6c0b11fb6ea4 Mon Sep 17 00:00:00 2001
+From 1cee2525a58f543fefb0d4ac696d3c9daff7fbe5 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 20, 21, and 22
@@ -33,9 +33,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/21.3.8.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/21.3.8.4/0003-Link-with-LDLIBS-instead-of-LIBS-for-DED.patch
  create mode 100644 package/erlang/21.3.8.4/0004-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/22.3.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
- create mode 100644 package/erlang/22.3.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/22.3.1/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/22.3.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/22.3.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/22.3.3/0003-erlang-enable-deterministic-builds.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -548,11 +548,11 @@ index 0000000000..1a7e66eca5
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.3.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.3.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+diff --git a/package/erlang/22.3.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/22.3.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
 index 0000000000..4d3dd75ce2
 --- /dev/null
-+++ b/package/erlang/22.3.1/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
++++ b/package/erlang/22.3.3/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 @@ -0,0 +1,71 @@
 +From 7040c252fb45e5423512094a1c9ca4a0a8fc77f0 Mon Sep 17 00:00:00 2001
 +From: "Yann E. MORIN" <yann.morin.1998@free.fr>
@@ -625,11 +625,11 @@ index 0000000000..4d3dd75ce2
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.3.1/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.3.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/22.3.3/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/22.3.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..7f2585870a
 --- /dev/null
-+++ b/package/erlang/22.3.1/0002-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/22.3.3/0002-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From 2142338c7a82360087a21dc71cfdad777d43e6a8 Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -680,11 +680,11 @@ index 0000000000..7f2585870a
 +-- 
 +2.17.1
 +
-diff --git a/package/erlang/22.3.1/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.3.1/0003-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/22.3.3/0003-erlang-enable-deterministic-builds.patch b/package/erlang/22.3.3/0003-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..043c6f48c6
 --- /dev/null
-+++ b/package/erlang/22.3.1/0003-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/22.3.3/0003-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From fed869414aa22aeea1c6e971a0600df3d5d0077e Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -748,7 +748,7 @@ index ab87eab6ff..141759ea70 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 3c2f039496..3a9c48789f 100644
+index 3c2f039496..fba78efdc0 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,4 +1,5 @@
@@ -756,12 +756,12 @@ index 3c2f039496..3a9c48789f 100644
 -md5 b2b48dad6e69c1e882843edbf2abcfd3  otp_src_22.2.tar.gz
 -sha256 89c2480cdac566065577c82704a48e10f89cf2e6ca5ab99e1cf80027784c678f  otp_src_22.2.tar.gz
 +# sha256 locally computed
-+sha256 34677d4604b6357db03b6cf79226d9fc1bbdf0ecb5e7545f2fe7a834cec93a83  OTP-22.3.1.tar.gz
++sha256 58ef3623cad5f490fdc0719514fe1a9626c8b177a4fb8fa25b5bec0216693eb9  OTP-22.3.3.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 836edf9bce..bad2c054ab 100644
+index 836edf9bce..dd47263ca4 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -5,7 +5,16 @@
@@ -775,7 +775,7 @@ index 836edf9bce..bad2c054ab 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_21),y)
 +ERLANG_VERSION = 21.3.8.4
 +else
-+ERLANG_VERSION = 22.3.1
++ERLANG_VERSION = 22.3.3
 +endif
 +endif
 +

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -6,7 +6,7 @@ description="Container with everything needed to build Nerves Systems"
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV ERLANG_OTP_VERSION=22.3.1-1
+ENV ERLANG_OTP_VERSION=22.3.2-1
 ENV FWUP_VERSION=1.6.0
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"


### PR DESCRIPTION
This bumps Erlang from 22.3.1 to 22.3.3. See the following release notes
for changes:

* https://erlang.org/download/OTP-22.3.3.README
* https://erlang.org/download/OTP-22.3.2.README