### PR TITLE
fwup: bump to v1.7.0

### DIFF
--- a/patches/buildroot/0011-fwup-bump-to-v1.7.0.patch
+++ b/patches/buildroot/0011-fwup-bump-to-v1.7.0.patch
@@ -1,7 +1,7 @@
-From 2f4f46bd6a9124a7bd5483afeb92982c62ac5d38 Mon Sep 17 00:00:00 2001
+From ecfd2c6323b58f2a00fc76a1da03f7769ce60bd9 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Thu, 4 Oct 2018 23:12:34 -0400
-Subject: [PATCH] fwup: bump to v1.6.0
+Subject: [PATCH] fwup: bump to v1.7.0
 
 ---
  package/fwup/Config.in | 1 -
@@ -22,16 +22,16 @@ index fd40cf3261..0e3c57d33d 100644
  	  Fwup is a scriptable embedded Linux firmware update creator
  	  and runner.
 diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
-index 337883f9a8..b59547514b 100644
+index 337883f9a8..6ee1c7e668 100644
 --- a/package/fwup/fwup.hash
 +++ b/package/fwup/fwup.hash
 @@ -1,3 +1,3 @@
  # Locally calculated
 -sha256 20302dc96cef88438034e15551e178bb0652c28d99aa7ca5260100cb3bebbc2a  fwup-1.2.5.tar.gz
-+sha256 56373e2efa15e3494cf75d09b738c07b409a6d7be00829d64c108f86db9bb438  fwup-1.6.0.tar.gz
++sha256 ac84626cfc6b674f1a6a8b5600edb331eeed8bbc5d46318e5c470bc53bafb2bd  fwup-1.7.0.tar.gz
  sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
 diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
-index e1e5467765..2e5c278c87 100644
+index e1e5467765..fe63e46a8d 100644
 --- a/package/fwup/fwup.mk
 +++ b/package/fwup/fwup.mk
 @@ -4,14 +4,15 @@
@@ -39,7 +39,7 @@ index e1e5467765..2e5c278c87 100644
  ################################################################################
  
 -FWUP_VERSION = 1.2.5
-+FWUP_VERSION = 1.6.0
++FWUP_VERSION = 1.7.0
  FWUP_SITE = $(call github,fhunleth,fwup,v$(FWUP_VERSION))
  FWUP_LICENSE = Apache-2.0
  FWUP_LICENSE_FILES = LICENSE


### PR DESCRIPTION
From the release notes:

In this release, `fwup` verifies writes to raw devices. Regular files
are not verified unless forced with the `--verify-writes` option. Writes
are verified as they're written. Since the final write with `fwup`
firmware updates is usually to toggle the active partition, corruption
can fail an update before the toggle occurs.

* New features
  * Writes verification on raw devices. This may be forced with
    `--verify-writes` or disabled with `--no-verify-writes`.
  * The `boot` option works for GPT partitions now. `boot=true` will set
    the GPT attribute flags appropriately. Since the archive creation
    process replaces the `boot` parameter with raw flags, older versions
    of `fwup` can apply updates that use this.

* Bug fixes
  * After a write error was detected, `fwup` would continue to try to
    write a few more blocks before exiting. Now it no longer writes
    after an error. An `on-error` handle can perform a write, but it
    will start from a clean slate now.