### PR TITLE
fwup: bump to v1.8.0

### DIFF
--- a/patches/buildroot/0010-fwup-bump-to-v1.8.0.patch
+++ b/patches/buildroot/0010-fwup-bump-to-v1.8.0.patch
@@ -1,7 +1,7 @@
-From 0aab9d5349ba011c3264d3bdb12ed77ccd0ddb18 Mon Sep 17 00:00:00 2001
+From 539605b868ac694308379668a8ee4cca4fed502f Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Thu, 4 Oct 2018 23:12:34 -0400
-Subject: [PATCH] fwup: bump to v1.7.0
+Subject: [PATCH] fwup: bump to v1.8.0
 
 ---
  package/fwup/Config.in | 1 -
@@ -22,16 +22,16 @@ index fd40cf3261..0e3c57d33d 100644
  	  Fwup is a scriptable embedded Linux firmware update creator
  	  and runner.
 diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
-index 337883f9a8..6ee1c7e668 100644
+index 337883f9a8..cd3f3bcefd 100644
 --- a/package/fwup/fwup.hash
 +++ b/package/fwup/fwup.hash
 @@ -1,3 +1,3 @@
  # Locally calculated
 -sha256 20302dc96cef88438034e15551e178bb0652c28d99aa7ca5260100cb3bebbc2a  fwup-1.2.5.tar.gz
-+sha256 ac84626cfc6b674f1a6a8b5600edb331eeed8bbc5d46318e5c470bc53bafb2bd  fwup-1.7.0.tar.gz
++sha256 9890f0328796f4315e6c1188df5c103855c530fbc14fbc8c12f4b24066c975f1  fwup-1.8.0.tar.gz
  sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
 diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
-index e1e5467765..fe63e46a8d 100644
+index e1e5467765..4fc3abce29 100644
 --- a/package/fwup/fwup.mk
 +++ b/package/fwup/fwup.mk
 @@ -4,14 +4,15 @@
@@ -39,7 +39,7 @@ index e1e5467765..fe63e46a8d 100644
  ################################################################################
  
 -FWUP_VERSION = 1.2.5
-+FWUP_VERSION = 1.7.0
++FWUP_VERSION = 1.8.0
  FWUP_SITE = $(call github,fhunleth,fwup,v$(FWUP_VERSION))
  FWUP_LICENSE = Apache-2.0
  FWUP_LICENSE_FILES = LICENSE

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -7,7 +7,7 @@ USER root
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV ERLANG_OTP_VERSION=23.0.2-1
-ENV FWUP_VERSION=1.7.0
+ENV FWUP_VERSION=1.8.0
 ENV ERLANG_PKG='erlang-solutions_1.0_all.deb'
 ENV ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}"
 ENV LANG C.UTF-8


### PR DESCRIPTION
fwup v1.8.0 adds support for redundant U-Boot environment blocks and
fixes memory leaks that don't affect Nerves.

To use redundant U-Boot environment blocks with Nerves, updates are
needed to the Elixir `uboot_env` package and this needs to be enabled on
Nerves systems.