### PR TITLE
rpi-firmware/userland bump to latest

### DIFF
--- a/patches/buildroot/0013-rpi-userland-bump-to-f97b1af1.patch
+++ b/patches/buildroot/0013-rpi-userland-bump-to-f97b1af1.patch
@@ -1,0 +1,35 @@
+From abb93eddc536e783411c89145683dfc61dba9c5f Mon Sep 17 00:00:00 2001
+From: Justin Schneck <jschneck@mac.com>
+Date: Fri, 5 Jun 2020 15:20:21 -0400
+Subject: [PATCH] rpi-userland bump to f97b1af1
+
+---
+ package/rpi-userland/rpi-userland.hash | 2 +-
+ package/rpi-userland/rpi-userland.mk   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/rpi-userland/rpi-userland.hash b/package/rpi-userland/rpi-userland.hash
+index 4a10536e74..4782ef00e8 100644
+--- a/package/rpi-userland/rpi-userland.hash
++++ b/package/rpi-userland/rpi-userland.hash
+@@ -1,3 +1,3 @@
+ # Locally computed
+-sha256  f81fe28c636178645fb406cc87f543efa828ca896df856536f7b1b4ab54dfe0e  rpi-userland-6fb59736b1ae80fc62cddfe3309c800f72e1c07e.tar.gz
++sha256  819cdf5aa81ec30adf33848cabc0aa5f603d3a36a6e3ff38a0e125acddc69c33  rpi-userland-f97b1af1b3e653f9da2c1a3643479bfd469e3b74.tar.gz
+ sha256  bee6f1249175683d8610651706e1aa7dffcbfd3f9c4c05bc1e5ab34f313c2db5  LICENCE
+diff --git a/package/rpi-userland/rpi-userland.mk b/package/rpi-userland/rpi-userland.mk
+index efb02f719f..713b44797b 100644
+--- a/package/rpi-userland/rpi-userland.mk
++++ b/package/rpi-userland/rpi-userland.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-RPI_USERLAND_VERSION = 6fb59736b1ae80fc62cddfe3309c800f72e1c07e
++RPI_USERLAND_VERSION = f97b1af1b3e653f9da2c1a3643479bfd469e3b74
+ RPI_USERLAND_SITE = $(call github,raspberrypi,userland,$(RPI_USERLAND_VERSION))
+ RPI_USERLAND_LICENSE = BSD-3-Clause
+ RPI_USERLAND_LICENSE_FILES = LICENCE
+-- 
+2.25.1
+

--- a/patches/buildroot/0014-rpi-firmware-bump-to-1.20200601.patch
+++ b/patches/buildroot/0014-rpi-firmware-bump-to-1.20200601.patch
@@ -1,7 +1,7 @@
-From 0d14c036848b3e1cbdf35f520d16f341b335887f Mon Sep 17 00:00:00 2001
-From: Frank Hunleth <fhunleth@troodon-software.com>
-Date: Mon, 9 Mar 2020 21:29:27 -0400
-Subject: [PATCH] rpi-firmware: bump to 1.20200212
+From 8fc44790ee62e2250399df4e37bd55ff027cbfc3 Mon Sep 17 00:00:00 2001
+From: Justin Schneck <jschneck@mac.com>
+Date: Fri, 5 Jun 2020 15:19:52 -0400
+Subject: [PATCH] rpi-firmware bump to 1.20200601
 
 ---
  package/rpi-firmware/rpi-firmware.hash | 4 ++--
@@ -9,19 +9,19 @@ Subject: [PATCH] rpi-firmware: bump to 1.20200212
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/package/rpi-firmware/rpi-firmware.hash b/package/rpi-firmware/rpi-firmware.hash
-index 01206f9066..8535904fb7 100644
+index 01206f9066..e65f3fd1ba 100644
 --- a/package/rpi-firmware/rpi-firmware.hash
 +++ b/package/rpi-firmware/rpi-firmware.hash
 @@ -1,5 +1,5 @@
  # Locally computed
 -sha256 ec2dbd3cd7654f743894ffb9100e7e86ef9d840e7cf113c0b517e0da42cbbb02 rpi-firmware-1.20190819.tar.gz
-+sha256 e3b0577beb62d886a45016447bdf8c2d57b794d3d71b502868b16ba82ff8fe43 rpi-firmware-1.20200212.tar.gz
++sha256 d826cdfdcf5931b5ccdcf89b206a83983bea8c94ec349552eeccdd20666430c0 rpi-firmware-1.20200601.tar.gz
  sha256 f1d631920ed4ae15f368ba7b8b3caa4ed604f5223372cc6debbd39a101eb8d74 rpi-firmware-81cca1a9380c828299e884dba5efd0d4acb39e8d.tar.gz
  sha256 5edff641f216d2e09c75469dc2e9fc66aff290e212a1cd43ed31c499f99ea055 rpi-firmware-287af2a2be0787a5d45281d1d6183a2161c798d4.tar.gz
 -sha256 ba76edfc10a248166d965b8eaf320771c44f4f432d4fce2fd31fd272e7038add boot/LICENCE.broadcom
 +sha256 c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b boot/LICENCE.broadcom
 diff --git a/package/rpi-firmware/rpi-firmware.mk b/package/rpi-firmware/rpi-firmware.mk
-index e78fd4853d..a2a935f433 100644
+index e78fd4853d..4b19a45772 100644
 --- a/package/rpi-firmware/rpi-firmware.mk
 +++ b/package/rpi-firmware/rpi-firmware.mk
 @@ -12,7 +12,7 @@ ifeq ($(BR2_PACKAGE_RPI_FIRMWARE_KERNEL_4_14),y)
@@ -29,7 +29,7 @@ index e78fd4853d..a2a935f433 100644
  else
  # Linux 4.19
 -RPI_FIRMWARE_VERSION = 1.20190819
-+RPI_FIRMWARE_VERSION = 1.20200212
++RPI_FIRMWARE_VERSION = 1.20200601
  endif
  endif
  


### PR DESCRIPTION
rpi-firmware 1.20200527
rpi-userland f97b1af1b3e653f9da2c1a3643479bfd469e3b74

Tested on rpi3a w/wifi