### PR TITLE
Add environment variable overrides for host builds

### DIFF
--- a/nerves_env.exs
+++ b/nerves_env.exs
@@ -156,6 +156,18 @@ System.put_env("ERTS_INCLUDE_DIR", "#{erts_dir}/include")
 System.put_env("ERL_INTERFACE_LIB_DIR", Path.join(erl_interface_dir, "lib"))
 System.put_env("ERL_INTERFACE_INCLUDE_DIR", Path.join(erl_interface_dir, "include"))
 
+# Host tools
+System.put_env("AR_FOR_BUILD", "ar")
+System.put_env("AS_FOR_BUILD", "as")
+System.put_env("CC_FOR_BUILD", "cc")
+System.put_env("GCC_FOR_BUILD", "gcc")
+System.put_env("CXX_FOR_BUILD", "g++")
+System.put_env("LD_FOR_BUILD", "ld")
+System.put_env("CPPFLAGS_FOR_BUILD", "")
+System.put_env("CFLAGS_FOR_BUILD", "")
+System.put_env("CXXFLAGS_FOR_BUILD", "")
+System.put_env("LDFLAGS_FOR_BUILD", "")
+
 host_erl_major_ver = :erlang.system_info(:otp_release) |> to_string
 [target_erl_major_version | _] =
   sdk_sysroot

--- a/scripts/nerves-env-helper.sh
+++ b/scripts/nerves-env-helper.sh
@@ -137,6 +137,18 @@ export ERTS_INCLUDE_DIR="$ERTS_DIR/include"
 export ERL_INTERFACE_LIB_DIR="$ERL_INTERFACE_DIR/lib"
 export ERL_INTERFACE_INCLUDE_DIR="$ERL_INTERFACE_DIR/include"
 
+# Host tools
+export AR_FOR_BUILD=ar
+export AS_FOR_BUILD=as
+export CC_FOR_BUILD=cc
+export GCC_FOR_BUILD=gcc
+export CXX_FOR_BUILD=g++
+export LD_FOR_BUILD=ld
+export CPPFLAGS_FOR_BUILD=
+export CFLAGS_FOR_BUILD=
+export CXXFLAGS_FOR_BUILD=
+export LDFLAGS_FOR_BUILD=
+
 # Since it is so important that the host and target Erlang installs
 # match, check it here.
 


### PR DESCRIPTION
This adds the `*_FOR_BUILD` environment variables so that it's possible
compile build tools. The `_FOR_BUILD` naming comes from Buildroot and
Autoconf.