### PR TITLE
Run CI for all branches, commits, and tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,11 +105,20 @@ workflows:
       jobs:
         - build:
             context: org-global
+            filters:
+              tags:
+                only: /.*/
         - push:
             context: org-global
             requires:
               - build
+            filters:
+              tags:
+                only: /.*/
         - test:
             context: org-global
             requires:
               - push
+            filters:
+              tags:
+                only: /.*/


### PR DESCRIPTION
From the circle CI Docs:
> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.

This PR _should_ fix CI so it always runs