### PR TITLE
Raspberry Pi Linux 5.4 support

### DIFF
--- a/patches/buildroot/0012-rpi-userland-bump-to-f73fca0.patch
+++ b/patches/buildroot/0012-rpi-userland-bump-to-f73fca0.patch
@@ -1,24 +1,25 @@
-From d8a580bb3834db86fbc805ee89d2c30736850a02 Mon Sep 17 00:00:00 2001
+From 2b5701db79e43e766a2d013dc638c0c97a6342c4 Mon Sep 17 00:00:00 2001
 From: Justin Schneck <jschneck@mac.com>
 Date: Fri, 5 Jun 2020 15:20:21 -0400
-Subject: [PATCH] rpi-userland bump to f97b1af1
+Subject: [PATCH] rpi-userland bump to f73fca0
 
+The date of this commit is August 13, 2020.
 ---
  package/rpi-userland/rpi-userland.hash | 2 +-
  package/rpi-userland/rpi-userland.mk   | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/package/rpi-userland/rpi-userland.hash b/package/rpi-userland/rpi-userland.hash
-index 0db5b7c83f..4782ef00e8 100644
+index 0db5b7c83f..83d7fce54f 100644
 --- a/package/rpi-userland/rpi-userland.hash
 +++ b/package/rpi-userland/rpi-userland.hash
 @@ -1,3 +1,3 @@
  # Locally computed
 -sha256  7c58d6b4cdf65acef0ce1f441606df87e25745f78d74e11930383d03100aff4b  rpi-userland-188d3bfe4a0ac36b119a2cee35a6be8d0c68e09e.tar.gz
-+sha256  819cdf5aa81ec30adf33848cabc0aa5f603d3a36a6e3ff38a0e125acddc69c33  rpi-userland-f97b1af1b3e653f9da2c1a3643479bfd469e3b74.tar.gz
++sha256  024cafd2f4428e96bff1d29a782db1d484d4f1835f64097ca1bd0dc38f75e84f  rpi-userland-f73fca015d421b763936667a0b58fe5024d59921.tar.gz
  sha256  bee6f1249175683d8610651706e1aa7dffcbfd3f9c4c05bc1e5ab34f313c2db5  LICENCE
 diff --git a/package/rpi-userland/rpi-userland.mk b/package/rpi-userland/rpi-userland.mk
-index 9edc92344e..713b44797b 100644
+index 9edc92344e..4cfd5cb832 100644
 --- a/package/rpi-userland/rpi-userland.mk
 +++ b/package/rpi-userland/rpi-userland.mk
 @@ -4,7 +4,7 @@
@@ -26,7 +27,7 @@ index 9edc92344e..713b44797b 100644
  ################################################################################
  
 -RPI_USERLAND_VERSION = 188d3bfe4a0ac36b119a2cee35a6be8d0c68e09e
-+RPI_USERLAND_VERSION = f97b1af1b3e653f9da2c1a3643479bfd469e3b74
++RPI_USERLAND_VERSION = f73fca015d421b763936667a0b58fe5024d59921
  RPI_USERLAND_SITE = $(call github,raspberrypi,userland,$(RPI_USERLAND_VERSION))
  RPI_USERLAND_LICENSE = BSD-3-Clause
  RPI_USERLAND_LICENSE_FILES = LICENCE

--- a/patches/buildroot/0013-linux-firmware-add-raspberry-pi-settings.patch
+++ b/patches/buildroot/0013-linux-firmware-add-raspberry-pi-settings.patch
@@ -1,0 +1,28 @@
+From 09cf5ddfc376d000a98746c0d6d13094bb1d6d5e Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Fri, 16 Oct 2020 14:35:05 -0400
+Subject: [PATCH] linux-firmware: add raspberry pi settings
+
+---
+ package/linux-firmware/linux-firmware.mk | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/package/linux-firmware/linux-firmware.mk b/package/linux-firmware/linux-firmware.mk
+index cbad8d592a..a68bfcb14d 100644
+--- a/package/linux-firmware/linux-firmware.mk
++++ b/package/linux-firmware/linux-firmware.mk
+@@ -542,7 +542,10 @@ LINUX_FIRMWARE_FILES += \
+ 	brcm/brcmfmac43362-sdio.bin brcm/brcmfmac43430-sdio.bin \
+ 	brcm/brcmfmac43430a0-sdio.bin brcm/brcmfmac43455-sdio.bin \
+ 	brcm/brcmfmac43569.bin brcm/brcmfmac43570-pcie.bin \
+-	brcm/brcmfmac43602-pcie.ap.bin brcm/brcmfmac43602-pcie.bin
++	brcm/brcmfmac43602-pcie.ap.bin brcm/brcmfmac43602-pcie.bin \
++	brcm/brcmfmac43430-sdio.raspberrypi,3-model-b.txt \
++	brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt \
++	brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+ LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.broadcom_bcm43xx
+ endif
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
This updates rpi-firmware, rpi-userland, and linux-firmware's Broadcom
WiFi driver installation to support Linux 5.4.

In addition to upgrading to Linux 5.4, systems will need to do the
following:

1. Change all references to `pi3-miniuart-bt` to `miniuart-bt`. This
   affects `fwup.conf` and `config.txt` files.
2. Deselect `BR2_RPI_WIFI_FIRMWARE` from the `nerves_defconfig` and add
   the following:
   ```
   BR2_PACKAGE_LINUX_FIRMWARE=y
   BR2_PACKAGE_LINUX_FIRMWARE_BRCM_BCM43XXX=y
   ```
3. Update the Linux kernel to Raspberry Pi's
   `raspberrypi-kernel_1.20200902-1` release.

The update from Linux 4.19 to 5.14 appears to not require many changes
to the Linux configuration. The main one appears to be that the
Raspberry Pi's touchscreen input driver changed names.