### PR TITLE
nerves-config: change config type

### DIFF
--- a/package/nerves-config/Config.in
+++ b/package/nerves-config/Config.in
@@ -1,4 +1,4 @@
-menuconfig BR2_PACKAGE_NERVES_CONFIG
+config BR2_PACKAGE_NERVES_CONFIG
 	bool "nerves-config"
 	select BR2_PACKAGE_ERLANG   # Erlang is required for all Nerves systems
 	select BR2_PACKAGE_ERLINIT  # Always use erlinit to boot


### PR DESCRIPTION
This package is a normal `config` now since it doesn't have any options.
This change fixes its presentation in `make menuconfig`.