### PR TITLE
boardid: bump to v1.10.0

### DIFF
--- a/package/boardid/boardid.hash
+++ b/package/boardid/boardid.hash
@@ -1,2 +1,2 @@
 # Locally computed
-sha256 02ab0e139cb59dd2991533c6c2558be31a4de3e00f22d889772b45785bb5e7f7  boardid-v1.9.0.tar.gz
+sha256 d6a09bbf7de5d8c419ecc1c9496bd3a26e0f45cf6f7cf31870c9801c0d94bc6d  boardid-v1.10.0.tar.gz

--- a/package/boardid/boardid.mk
+++ b/package/boardid/boardid.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-BOARDID_VERSION = v1.9.0
+BOARDID_VERSION = v1.10.0
 BOARDID_SITE = $(call github,nerves-project,boardid,$(BOARDID_VERSION))
 BOARDID_LICENSE = Apache-2.0
 BOARDID_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release adds support for 16+ character serial numbers for
NervesKeys and non-default I2C addresses for ATECC chips.