### PR TITLE
Support spaces in squashfs file paths

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -84,16 +84,23 @@ symlink_file() {
 }
 
 directory_file() {
-    pathname=$(get_path "$6")
+    perm="$1"
+    owner="$2"
+    shift 5
+    pathname="$(get_path "$@")"
     # mksquashfs doesn't support setting permissions and ownership
     # on the root directory
-    if [[ ! -z $pathname ]]; then
-        echo "$pathname m $(perm_to_num "$1") $(owner_to_uid_gid "$2")"
+    if [[ ! -z "$pathname" ]]; then
+        echo "$pathname m $(perm_to_num "$perm") $(owner_to_uid_gid "$owner")"
     fi
 }
 
 regular_file() {
-    echo "$(get_path "$6") m $(perm_to_num "$1") $(owner_to_uid_gid "$2")"
+    perm="$1"
+    owner="$2"
+    shift 5
+    pathname="$(get_path "$@")"
+    echo "$pathname m $(perm_to_num "$perm") $(owner_to_uid_gid "$owner")"
 }
 
 unsquash_to_pseudofile() {


### PR DESCRIPTION
This fixes the following warning that started appearing when the
Raspberry Pi WiFi firmware blobs introduced a file with a space in it.

```
Pseudo modify file "lib/firmware/brcm/brcmfmac43430a0-sdio.ONDA-V80" does not exist in source filesystem.  Ignoring.
```

The real filename is `/lib/firmware/brcm/brcmfmac43430a0-sdio.ONDA-V80\ PLUS.txt`.

The changes here fix the issue that was accidentally stripping off
everything after the space character.

To test, I built a Raspberry Pi Zero project and then ran `mix
firmware.unpack` to verify that the `brcmfmac...` file existed. The
warning also went away with this change.