### PR TITLE
Add support for the BeagleV RISC-V board

### DIFF
--- a/patches/buildroot/0013-boot-opensbi-add-support-for-version-configuration.patch
+++ b/patches/buildroot/0013-boot-opensbi-add-support-for-version-configuration.patch
@@ -1,0 +1,121 @@
+From 9fb53643db4a6f2549c7e09004481b3f6b08672f Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Thu, 29 Apr 2021 09:46:32 +0200
+Subject: [PATCH] boot/opensbi: add support for version configuration
+
+OpenSBI contains platform-specific code, so very much like Linux,
+U-Boot or other bootloaders, using the upstream version of OpenSBI
+will very often not be sufficient.
+
+This commit therefore adds the possibility of specifying a custom
+version of OpenSBI, either custom from upstream, custom tarball, or
+custom from Git. Support for other version control systems has not
+been implemented for now, but could be added later if needed.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ boot/opensbi/Config.in  | 51 +++++++++++++++++++++++++++++++++++++++++
+ boot/opensbi/opensbi.mk | 19 ++++++++++++++-
+ 2 files changed, 69 insertions(+), 1 deletion(-)
+
+diff --git a/boot/opensbi/Config.in b/boot/opensbi/Config.in
+index b9b0ace8af..83f40f04fa 100644
+--- a/boot/opensbi/Config.in
++++ b/boot/opensbi/Config.in
+@@ -13,6 +13,57 @@ config BR2_TARGET_OPENSBI
+ 	  https://github.com/riscv/opensbi.git
+ 
+ if BR2_TARGET_OPENSBI
++choice
++	prompt "OpenSBI Version"
++	help
++	  Select the specific OpenSBI version you want to use
++
++config BR2_TARGET_OPENSBI_LATEST_VERSION
++	bool "0.8"
++
++config BR2_TARGET_OPENSBI_CUSTOM_VERSION
++	bool "Custom version"
++	help
++	  This option allows to use a specific official versions
++
++config BR2_TARGET_OPENSBI_CUSTOM_TARBALL
++	bool "Custom tarball"
++
++config BR2_TARGET_OPENSBI_CUSTOM_GIT
++	bool "Custom Git repository"
++
++endchoice
++
++config BR2_TARGET_OPENSBI_CUSTOM_VERSION_VALUE
++	string "OpenSBI version"
++	depends on BR2_TARGET_OPENSBI_CUSTOM_VERSION
++
++config BR2_TARGET_OPENSBI_CUSTOM_TARBALL_LOCATION
++	string "URL of custom OpenSBI tarball"
++	depends on BR2_TARGET_OPENSBI_CUSTOM_TARBALL
++
++if BR2_TARGET_OPENSBI_CUSTOM_GIT
++
++config BR2_TARGET_OPENSBI_CUSTOM_REPO_URL
++	string "URL of custom repository"
++
++config BR2_TARGET_OPENSBI_CUSTOM_REPO_VERSION
++	string "Custom repository version"
++	help
++	  Revision to use in the typical format used by Git. E.G. a
++	  sha id, a tag, branch, ..
++
++endif
++
++config BR2_TARGET_OPENSBI_VERSION
++	string
++	default "0.8"	if BR2_TARGET_OPENSBI_LATEST_VERSION
++	default BR2_TARGET_OPENSBI_CUSTOM_VERSION_VALUE \
++		if BR2_TARGET_OPENSBI_CUSTOM_VERSION
++	default "custom"	if BR2_TARGET_OPENSBI_CUSTOM_TARBALL
++	default BR2_TARGET_OPENSBI_CUSTOM_REPO_VERSION \
++		if BR2_TARGET_OPENSBI_CUSTOM_GIT
++
+ config BR2_TARGET_OPENSBI_PLAT
+ 	string "OpenSBI Platform"
+ 	default ""
+diff --git a/boot/opensbi/opensbi.mk b/boot/opensbi/opensbi.mk
+index 60b87c268d..250a6078af 100644
+--- a/boot/opensbi/opensbi.mk
++++ b/boot/opensbi/opensbi.mk
+@@ -4,13 +4,30 @@
+ #
+ ################################################################################
+ 
+-OPENSBI_VERSION = 0.8
++OPENSBI_VERSION = $(call qstrip,$(BR2_TARGET_OPENSBI_VERSION))
++
++ifeq ($(OPENSBI_VERSION),custom)
++# Handle custom OpenSBI tarballs as specified by the configuration
++OPENSBI_TARBALL = $(call qstrip,$(BR2_TARGET_OPENSBI_CUSTOM_TARBALL_LOCATION))
++OPENSBI_SITE = $(patsubst %/,%,$(dir $(OPENSBI_TARBALL)))
++OPENSBI_SOURCE = $(notdir $(OPENSBI_TARBALL))
++else ifeq ($(BR2_TARGET_OPENSBI_CUSTOM_GIT),y)
++OPENSBI_SITE = $(call qstrip,$(BR2_TARGET_OPENSBI_CUSTOM_REPO_URL))
++OPENSBI_SITE_METHOD = git
++else
++# Handle official OpenSBI versions
+ OPENSBI_SITE = $(call github,riscv,opensbi,v$(OPENSBI_VERSION))
++endif
++
+ OPENSBI_LICENSE = BSD-2-Clause
+ OPENSBI_LICENSE_FILES = COPYING.BSD
+ OPENSBI_INSTALL_TARGET = NO
+ OPENSBI_INSTALL_STAGING = YES
+ 
++ifeq ($(BR2_TARGET_OPENSBI)$(BR2_TARGET_OPENSBI_LATEST_VERSION),y)
++BR_NO_CHECK_HASH_FOR += $(OPENSBI_SOURCE)
++endif
++
+ OPENSBI_MAKE_ENV = \
+ 	CROSS_COMPILE=$(TARGET_CROSS)
+ 
+-- 
+2.25.1
+

--- a/patches/buildroot/0014-boot-opensbi-allow-using-U-Boot-as-a-payload.patch
+++ b/patches/buildroot/0014-boot-opensbi-allow-using-U-Boot-as-a-payload.patch
@@ -1,0 +1,61 @@
+From cf02d1539fee874ba8b42a9bef60da139dd9dbfb Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Thu, 29 Apr 2021 09:46:33 +0200
+Subject: [PATCH] boot/opensbi: allow using U-Boot as a payload
+
+The opensbi package already allows to use Linux as a payload for
+OpenSBI, but in some cases, U-Boot as payload is useful. This commit
+adds a BR2_TARGET_OPENSBI_UBOOT_PAYLOAD option, modeled after the
+existing BR2_TARGET_OPENSBI_LINUX_PAYLOAD.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ boot/opensbi/Config.in  | 7 +++++++
+ boot/opensbi/opensbi.mk | 8 ++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/boot/opensbi/Config.in b/boot/opensbi/Config.in
+index 83f40f04fa..236bf74a90 100644
+--- a/boot/opensbi/Config.in
++++ b/boot/opensbi/Config.in
+@@ -82,4 +82,11 @@ config BR2_TARGET_OPENSBI_LINUX_PAYLOAD
+ 	help
+ 	  Build OpenSBI with the Linux kernel as a Payload.
+ 
++config BR2_TARGET_OPENSBI_UBOOT_PAYLOAD
++	bool "Include U-Boot as OpenSBI Payload"
++	depends on BR2_TARGET_OPENSBI_PLAT != ""
++	depends on BR2_TARGET_UBOOT
++	help
++	  Build OpenSBI with the U-Boot as a Payload.
++
+ endif
+diff --git a/boot/opensbi/opensbi.mk b/boot/opensbi/opensbi.mk
+index 250a6078af..8ebe4566fd 100644
+--- a/boot/opensbi/opensbi.mk
++++ b/boot/opensbi/opensbi.mk
+@@ -41,6 +41,11 @@ OPENSBI_DEPENDENCIES += linux
+ OPENSBI_MAKE_ENV += FW_PAYLOAD_PATH="$(BINARIES_DIR)/Image"
+ endif
+ 
++ifeq ($(BR2_TARGET_OPENSBI_UBOOT_PAYLOAD),y)
++OPENSBI_DEPENDENCIES += uboot
++OPENSBI_MAKE_ENV += FW_PAYLOAD_PATH="$(BINARIES_DIR)/u-boot.bin"
++endif
++
+ define OPENSBI_BUILD_CMDS
+ 	$(TARGET_MAKE_ENV) $(OPENSBI_MAKE_ENV) $(MAKE) -C $(@D)
+ endef
+@@ -51,6 +56,9 @@ OPENSBI_FW_IMAGES += jump dynamic
+ ifeq ($(BR2_TARGET_OPENSBI_LINUX_PAYLOAD),y)
+ OPENSBI_FW_IMAGES += payload
+ endif
++ifeq ($(BR2_TARGET_OPENSBI_UBOOT_PAYLOAD),y)
++OPENSBI_FW_IMAGES = payload
++endif
+ endif
+ 
+ define OPENSBI_INSTALL_IMAGES_CMDS
+-- 
+2.25.1
+

--- a/patches/buildroot/0015-boot-opensbi-add-options-to-enable-disable-image-ins.patch
+++ b/patches/buildroot/0015-boot-opensbi-add-options-to-enable-disable-image-ins.patch
@@ -1,0 +1,105 @@
+From 2d8208219c5dddda575302cf9fc23f67ca0c86d4 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Thu, 29 Apr 2021 09:46:34 +0200
+Subject: [PATCH] boot/opensbi: add options to enable/disable image
+ installation
+
+Until now, whenever a BR2_TARGET_OPENSBI_PLAT value was specified,
+opensbi.mk was assuming that both fw_jump and fw_dynamic would be
+produced. However, this is not the case: the OpenSBI per-platform
+config.mk can decide which image to build.
+
+As an example, the config.mk for VIC7100-based BeagleV only enables
+producing the fw_payload image.
+
+This commit adds three options to enable the installation of images:
+one for fw_jump, one for fw_dynamic, one for fw_payload.
+
+The options for fw_jump and fw_dynamic are "default y" when
+BR2_TARGET_OPENSBI_PLAT is not empty, to preserve existing behavior.
+
+The option for fw_payload is forcefully selected when either Linux or
+U-Boot are selected as payloads.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ boot/opensbi/Config.in  | 20 ++++++++++++++++++++
+ boot/opensbi/opensbi.mk | 16 ++++++++++------
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/boot/opensbi/Config.in b/boot/opensbi/Config.in
+index 236bf74a90..fb7c86d398 100644
+--- a/boot/opensbi/Config.in
++++ b/boot/opensbi/Config.in
+@@ -74,11 +74,30 @@ config BR2_TARGET_OPENSBI_PLAT
+ 	  the platform specific static library libplatsbi.a and firmware
+ 	  examples are built.
+ 
++config BR2_TARGET_OPENSBI_INSTALL_JUMP_IMG
++	bool "Install jump image"
++	default y if BR2_TARGET_OPENSBI_PLAT != ""
++	help
++	  This installs the fw_jump image.
++
++config BR2_TARGET_OPENSBI_INSTALL_DYNAMIC_IMG
++	bool "Install fw_dynamic image"
++	default y if BR2_TARGET_OPENSBI_PLAT != ""
++	help
++	  This installs the fw_dynamic image.
++
++config BR2_TARGET_OPENSBI_INSTALL_PAYLOAD_IMG
++	bool "Install fw_payload image"
++	help
++	  This option enables the installation of the fw_paylaod
++	  image.
++
+ config BR2_TARGET_OPENSBI_LINUX_PAYLOAD
+ 	bool "Include Linux as OpenSBI Payload"
+ 	depends on BR2_TARGET_OPENSBI_PLAT != ""
+ 	depends on BR2_LINUX_KERNEL
+ 	depends on BR2_LINUX_KERNEL_IMAGE
++	select BR2_TARGET_OPENSBI_INSTALL_PAYLOAD_IMG
+ 	help
+ 	  Build OpenSBI with the Linux kernel as a Payload.
+ 
+@@ -86,6 +105,7 @@ config BR2_TARGET_OPENSBI_UBOOT_PAYLOAD
+ 	bool "Include U-Boot as OpenSBI Payload"
+ 	depends on BR2_TARGET_OPENSBI_PLAT != ""
+ 	depends on BR2_TARGET_UBOOT
++	select BR2_TARGET_OPENSBI_INSTALL_PAYLOAD_IMG
+ 	help
+ 	  Build OpenSBI with the U-Boot as a Payload.
+ 
+diff --git a/boot/opensbi/opensbi.mk b/boot/opensbi/opensbi.mk
+index 8ebe4566fd..ee562dff53 100644
+--- a/boot/opensbi/opensbi.mk
++++ b/boot/opensbi/opensbi.mk
+@@ -50,15 +50,19 @@ define OPENSBI_BUILD_CMDS
+ 	$(TARGET_MAKE_ENV) $(OPENSBI_MAKE_ENV) $(MAKE) -C $(@D)
+ endef
+ 
+-ifneq ($(OPENSBI_PLAT),)
++ifeq ($(BR2_TARGET_OPENSBI_INSTALL_JUMP_IMG),y)
+ OPENSBI_INSTALL_IMAGES = YES
+-OPENSBI_FW_IMAGES += jump dynamic
+-ifeq ($(BR2_TARGET_OPENSBI_LINUX_PAYLOAD),y)
+-OPENSBI_FW_IMAGES += payload
++OPENSBI_FW_IMAGES += jump
+ endif
+-ifeq ($(BR2_TARGET_OPENSBI_UBOOT_PAYLOAD),y)
+-OPENSBI_FW_IMAGES = payload
++
++ifeq ($(BR2_TARGET_OPENSBI_INSTALL_DYNAMIC_IMG),y)
++OPENSBI_INSTALL_IMAGES = YES
++OPENSBI_FW_IMAGES += dynamic
+ endif
++
++ifeq ($(BR2_TARGET_OPENSBI_INSTALL_PAYLOAD_IMG),y)
++OPENSBI_INSTALL_IMAGES = YES
++OPENSBI_FW_IMAGES += payload
+ endif
+ 
+ define OPENSBI_INSTALL_IMAGES_CMDS
+-- 
+2.25.1
+

--- a/patches/buildroot/0016-configs-beaglev_defconfig-new-defconfig.patch
+++ b/patches/buildroot/0016-configs-beaglev_defconfig-new-defconfig.patch
@@ -1,0 +1,274 @@
+From b046264ce76d97f502d350b8c53e2a4419a6d169 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Thu, 29 Apr 2021 09:46:35 +0200
+Subject: [PATCH] configs/beaglev_defconfig: new defconfig
+
+This commit introduces support for the RISC-V based Beagle-V platform,
+which uses a Starfive VIC-7100.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ DEVELOPERS                                    |  2 +
+ board/beaglev/extlinux.conf                   |  4 +
+ board/beaglev/genimage.cfg                    | 12 +++
+ ...s-starfive-vic7100-adjust-fdt_addr_r.patch | 39 +++++++++
+ board/beaglev/post-build.sh                   | 17 ++++
+ board/beaglev/readme.txt                      | 86 +++++++++++++++++++
+ configs/beaglev_defconfig                     | 35 ++++++++
+ 7 files changed, 195 insertions(+)
+ create mode 100644 board/beaglev/extlinux.conf
+ create mode 100644 board/beaglev/genimage.cfg
+ create mode 100644 board/beaglev/patches/uboot/0001-include-configs-starfive-vic7100-adjust-fdt_addr_r.patch
+ create mode 100755 board/beaglev/post-build.sh
+ create mode 100644 board/beaglev/readme.txt
+ create mode 100644 configs/beaglev_defconfig
+
+diff --git a/DEVELOPERS b/DEVELOPERS
+index 53626566b3..7aef0c5f7a 100644
+--- a/DEVELOPERS
++++ b/DEVELOPERS
+@@ -2567,10 +2567,12 @@ F:	package/xorcurses/
+ 
+ N:	Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+ F:	arch/Config.in.arm
++F:	board/beaglev/
+ F:	board/stmicroelectronics/stm32mp157c-dk2/
+ F:	boot/boot-wrapper-aarch64/
+ F:	boot/grub2/
+ F:	boot/gummiboot/
++F:	configs/beaglev_defconfig
+ F:	configs/stm32mp157c_dk2_defconfig
+ F:	package/android-tools/
+ F:	package/b43-firmware/
+diff --git a/board/beaglev/extlinux.conf b/board/beaglev/extlinux.conf
+new file mode 100644
+index 0000000000..c5444d094c
+--- /dev/null
++++ b/board/beaglev/extlinux.conf
+@@ -0,0 +1,4 @@
++label linux
++  kernel /boot/Image
++  devicetree /boot/starfive_vic7100_beagle_v.dtb
++  append console=ttyS0,115200 earlyprintk root=PARTUUID=0fef845a-c6e1-45bc-82f7-002fa720f958 rootwait
+diff --git a/board/beaglev/genimage.cfg b/board/beaglev/genimage.cfg
+new file mode 100644
+index 0000000000..f38bb7f86c
+--- /dev/null
++++ b/board/beaglev/genimage.cfg
+@@ -0,0 +1,12 @@
++image sdcard.img {
++  hdimage {
++    gpt = true
++  }
++
++  partition rootfs {
++    partition-type-uuid = 72ec70a6-cf74-40e6-bd49-4bda08e8f224
++    partition-uuid = 0fef845a-c6e1-45bc-82f7-002fa720f958
++    bootable = "true"
++    image = "rootfs.ext4"
++  }
++}
+diff --git a/board/beaglev/patches/uboot/0001-include-configs-starfive-vic7100-adjust-fdt_addr_r.patch b/board/beaglev/patches/uboot/0001-include-configs-starfive-vic7100-adjust-fdt_addr_r.patch
+new file mode 100644
+index 0000000000..74d70f2721
+--- /dev/null
++++ b/board/beaglev/patches/uboot/0001-include-configs-starfive-vic7100-adjust-fdt_addr_r.patch
+@@ -0,0 +1,39 @@
++From 2c4c813940c577590f3352cef0c49a8def17905d Mon Sep 17 00:00:00 2001
++From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
++Date: Wed, 28 Apr 2021 22:58:45 +0200
++Subject: [PATCH] include/configs/starfive-vic7100: adjust fdt_addr_r
++
++The default fdt_addr_r of 0x88000000 doesn't work, the kernel never
++boots. Using 0x90000000 works fine.
++
++Since it would overlap with the kernel_comp_addr_r area, this one is
++moved 16 MB further, at 0x91000000.
++
++Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
++---
++ include/configs/starfive-vic7100.h | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/include/configs/starfive-vic7100.h b/include/configs/starfive-vic7100.h
++index 8c5915a73c..7150a23873 100644
++--- a/include/configs/starfive-vic7100.h
+++++ b/include/configs/starfive-vic7100.h
++@@ -111,13 +111,13 @@
++ 	"fdt_high=0xffffffffffffffff\0" \
++ 	"initrd_high=0xffffffffffffffff\0" \
++ 	"kernel_addr_r=0x84000000\0" \
++-	"fdt_addr_r=0x88000000\0" \
+++	"fdt_addr_r=0x90000000\0" \
++ 	"scriptaddr=0x88100000\0" \
++ 	"script_offset_f=0x1fff000\0" \
++ 	"script_size_f=0x1000\0" \
++ 	"pxefile_addr_r=0x88200000\0" \
++ 	"ramdisk_addr_r=0x88300000\0" \
++-	"kernel_comp_addr_r=0x90000000\0" \
+++	"kernel_comp_addr_r=0x91000000\0" \
++ 	"kernel_comp_size=0x10000000\0" \
++ 	"type_guid_gpt_loader1=" TYPE_GUID_LOADER1 "\0" \
++ 	"type_guid_gpt_loader2=" TYPE_GUID_LOADER2 "\0" \
++-- 
++2.30.2
++
+diff --git a/board/beaglev/post-build.sh b/board/beaglev/post-build.sh
+new file mode 100755
+index 0000000000..0e7337c96d
+--- /dev/null
++++ b/board/beaglev/post-build.sh
+@@ -0,0 +1,17 @@
++#!/bin/sh
++BOARD_DIR=$(dirname $0)
++
++# The DTB to use is provided within the U-Boot source tree, so we grab
++# it from there, and install it to TARGET_DIR/boot/.
++UBOOT_DIR=$(make --no-print-directory VARS=UBOOT_DIR printvars | cut -f2 -d'=')
++install -D -m0644 ${UBOOT_DIR}/arch/riscv/dts/starfive_vic7100_beagle_v.dtb \
++	${TARGET_DIR}/boot/starfive_vic7100_beagle_v.dtb
++
++# Bring the extlinux.conf file in.
++install -D -m 0644 ${BOARD_DIR}/extlinux.conf \
++	${TARGET_DIR}/boot/extlinux/extlinux.conf
++
++# To be reflashed through Xmodem, the bootloader needs to be prepended
++# with a 4-byte header that contains the total size of the file.
++perl -e 'print pack("l", (stat @ARGV[0])[7])' ${BINARIES_DIR}/fw_payload.bin > ${BINARIES_DIR}/fw_payload.bin.flash
++cat ${BINARIES_DIR}/fw_payload.bin >> ${BINARIES_DIR}/fw_payload.bin.flash
+diff --git a/board/beaglev/readme.txt b/board/beaglev/readme.txt
+new file mode 100644
+index 0000000000..903dd7975e
+--- /dev/null
++++ b/board/beaglev/readme.txt
+@@ -0,0 +1,86 @@
++Beagle-V
++========
++
++Beagle-V is a low-cost RISC-V 64-bit based platform, powered by a
++Starfive VIC-7100 processor.
++
++How to build
++============
++
++$ make beaglev_defconfig
++$ make
++
++Build results
++=============
++
++After building, output/images contains:
++
+++ Image
+++ fw_payload.bin
+++ fw_payload.bin.flash
+++ fw_payload.elf
+++ rootfs.ext2
+++ rootfs.ext4
+++ sdcard.img
+++ u-boot.bin
++
++The two important files are:
++
++ - fw_payload.bin.flash, which is the bootloader image, containing
++   both OpenSBI and U-Boot.
++
++ - sdcard.img, the SD card image, which contains the root filesystem,
++   kernel image and Device Tree.
++
++Flashing the SD card image
++==========================
++
++$ sudo dd if=output/images/sdcard.img of=/dev/sdX
++
++Preparing the board
++===================
++
++Connect the Beagle-V fan to the 5V supply (pin 2 or 4 of the GPIO
++connector) and GND (pin 6 of the GPIO connector).
++
++Connect a TTL UART cable to pin 8 (TX), 10 (RX) and 14 (GND).
++
++Insert your SD card.
++
++Power-up the board using an USB-C cable.
++
++Flashing the bootloader
++=======================
++
++The bootloader pre-flashed on the Beagle-V has a non-working
++fdt_addr_r environment variable value, so it won't work
++as-is. Reflashing the bootloader with the bootloader image produced by
++Buildroot is necessary.
++
++When the board starts up, a pre-loader shows a count down of 2
++seconds, interrupt by pressing any key. You should reach a menu like
++this:
++
++--------8<----------
++
++bootloader version:210209-4547a8d
++ddr 0x00000000, 1M test
++ddr 0x00100000, 2M test
++DDR clk 2133M,Version: 210302-5aea32f
++0
++***************************************************
++*************** FLASH PROGRAMMING *****************
++***************************************************
++
++0:update uboot
++1:quit
++select the function:
++
++--------8<----------
++
++Press 0 and Enter. You will now see "C" characters being
++displayed. Ask your serial port communication program to send
++fw_payload.bin.flash using the Xmodem protocol.
++
++After reflashing is complete, restart the board, it will automatically
++start the system from the SD card, and reach the login prompt.
+diff --git a/configs/beaglev_defconfig b/configs/beaglev_defconfig
+new file mode 100644
+index 0000000000..097d4c5302
+--- /dev/null
++++ b/configs/beaglev_defconfig
+@@ -0,0 +1,35 @@
++BR2_riscv=y
++BR2_riscv_custom=y
++BR2_RISCV_ISA_CUSTOM_RVM=y
++BR2_RISCV_ISA_CUSTOM_RVF=y
++BR2_RISCV_ISA_CUSTOM_RVD=y
++BR2_RISCV_ISA_CUSTOM_RVC=y
++BR2_GLOBAL_PATCH_DIR="board/beaglev/patches/"
++BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
++BR2_ROOTFS_POST_BUILD_SCRIPT="board/beaglev/post-build.sh"
++BR2_ROOTFS_POST_IMAGE_SCRIPT="support/scripts/genimage.sh"
++BR2_ROOTFS_POST_SCRIPT_ARGS="-c board/beaglev/genimage.cfg"
++BR2_LINUX_KERNEL=y
++BR2_LINUX_KERNEL_CUSTOM_TARBALL=y
++# HEAD of the Fedora branch
++BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="$(call github,starfive-tech,beagle_kernel_5.10,710cf052d6abda73584481d920b4b6befc7240ea)/linux-710cf052d6abda73584481d920b4b6befc7240ea.tar.gz"
++BR2_LINUX_KERNEL_DEFCONFIG="starfive_vic7100_evb_sd_net"
++BR2_LINUX_KERNEL_INSTALL_TARGET=y
++BR2_TARGET_ROOTFS_EXT2=y
++BR2_TARGET_ROOTFS_EXT2_4=y
++# BR2_TARGET_ROOTFS_TAR is not set
++BR2_TARGET_OPENSBI=y
++BR2_TARGET_OPENSBI_CUSTOM_TARBALL=y
++# HEAD of the Fedora branch
++BR2_TARGET_OPENSBI_CUSTOM_TARBALL_LOCATION="$(call github,starfive-tech,beagle_opensbi,2524b0ecd8684b42bc7a4c69794f40f11cbbe2a5)/opensbi-2524b0ecd8684b42bc7a4c69794f40f11cbbe2a5.tar.gz"
++BR2_TARGET_OPENSBI_PLAT="starfive/vic7100"
++# BR2_TARGET_OPENSBI_INSTALL_JUMP_IMG is not set
++# BR2_TARGET_OPENSBI_INSTALL_DYNAMIC_IMG is not set
++BR2_TARGET_OPENSBI_UBOOT_PAYLOAD=y
++BR2_TARGET_UBOOT=y
++BR2_TARGET_UBOOT_BUILD_SYSTEM_KCONFIG=y
++BR2_TARGET_UBOOT_CUSTOM_TARBALL=y
++# HEAD of the Fedora branch
++BR2_TARGET_UBOOT_CUSTOM_TARBALL_LOCATION="$(call github,starfive-tech,beagle_uboot-opensbi,3f3ac01a29ad1cd5fa519d86f81daead2447f1d4)/uboot-3f3ac01a29ad1cd5fa519d86f81daead2447f1d4.tar.gz"
++BR2_TARGET_UBOOT_BOARD_DEFCONFIG="starfive_vic7100_beagle_v_smode"
++BR2_PACKAGE_HOST_GENIMAGE=y
+-- 
+2.25.1
+

--- a/patches/buildroot/0017-erlang-add-RISC-V-to-the-supported-architectures.patch
+++ b/patches/buildroot/0017-erlang-add-RISC-V-to-the-supported-architectures.patch
@@ -1,0 +1,26 @@
+From 18daa9e666939138e8c9145df8674e6271023b21 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 29 Apr 2021 13:45:33 -0400
+Subject: [PATCH] erlang: add RISC-V to the supported architectures
+
+Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
+---
+ package/erlang/Config.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package/erlang/Config.in b/package/erlang/Config.in
+index 17b97bed3d..3ed663039e 100644
+--- a/package/erlang/Config.in
++++ b/package/erlang/Config.in
+@@ -8,7 +8,7 @@ config BR2_PACKAGE_ERLANG_ARCH_SUPPORTS
+ 	# see HOWTO/INSTALL.md for Erlang's supported platforms
+ 	# when using its native atomic ops implementation
+ 	default y if BR2_i386 || BR2_x86_64 || BR2_powerpc || \
+-		BR2_sparc_v9 || BR2_arm || BR2_aarch64 || BR2_mipsel
++		BR2_sparc_v9 || BR2_arm || BR2_aarch64 || BR2_mipsel || BR2_riscv
+ 	# erlang needs host-erlang
+ 	depends on BR2_PACKAGE_HOST_ERLANG_ARCH_SUPPORTS
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
This pulls in patches from upstream Buildroot and adds one to enable
Erlang to be built.

These patches build, but have not been tested yet.
