### PR TITLE
Bump Broadcom WiFi firmware for Raspberry Pis

### DIFF
--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,5 +1,5 @@
 # Locally computed
-sha256  033a21d19fbdc7617b8c5b58d4be5951e29be5be787a45875b615f4d4dcf3f5b  rpi-distro-firmware-nonfree-b66ab26cebff689d0d3257f56912b9bb03c20567.tar.gz
+sha256  f8b3af1f394d7a820871d03ac0e7c58ebc1bd556812f4a27cd48eef330c57b00  rpi-distro-firmware-nonfree-83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5.tar.gz
 sha256  8116433f4004fc0c24d72b3d9e497808b724aa0e5e1cd63fc1bf66b715b1e2e9  LICENCE.Abilis
 sha256  69f29eee4ad020ef08c469bddd68b565edce7adad627f93ad329ef9198a9e9f9  LICENCE.adsp_sst
 sha256  33a25775e426c44cfa5b8bd9dfa0c1dae7de0a90358a7b8f7054023189f1e0e0  LICENCE.agere

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = b66ab26cebff689d0d3257f56912b9bb03c20567 # 1:20190114-1+rpt10 release
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5 # 1:20190114-1+rpt11 release
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = LICENCE.broadcom_bcm43xx LICENCE.cypress
 


### PR DESCRIPTION
This has the following comment:

```
firmware-nonfree (1:20190114-1+rpt11) buster; urgency=medium

  * Update CYW43455 firmware
    - brcm/brcmfmac43455-sdio.bin 7.45.229
    - See: https://github.com/raspberrypi/linux/issues/3849

 -- Serge Schneider <serge@raspberrypi.com>  Mon, 25 Jan 2021 10:17:21 +0000
```
