### PR TITLE
erlang: bump to 24.0.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 23.3.4
+erlang 24.0.2

--- a/patches/buildroot/0009-erlang-support-OTP-20-24.patch
+++ b/patches/buildroot/0009-erlang-support-OTP-20-24.patch
@@ -1,9 +1,9 @@
-From b6c73efa970b3668d501292c10be3b2bfa7e49c0 Mon Sep 17 00:00:00 2001
+From 3713b25afc49747729fb856f94cf57b9ef348586 Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
-Subject: [PATCH] erlang: support OTP 20 - 23
+Subject: [PATCH] erlang: support OTP 20 - 24
 
-This also adds the deterministic compile flag patch for OTP 21-23.
+This also adds the deterministic compile flag patch for OTP 21-24.
 
 Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
 ---
@@ -24,10 +24,14 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  ...ulator-reorder-inclued-headers-paths.patch | 49 +++++++++++++
  ...3-erlang-enable-deterministic-builds.patch | 28 ++++++++
  ...-update-df-call-to-work-with-Busybox.patch | 28 ++++++++
- package/erlang/Config.in                      | 27 +++++++
- package/erlang/erlang.hash                    |  8 ++-
- package/erlang/erlang.mk                      | 29 +++++++-
- 20 files changed, 752 insertions(+), 121 deletions(-)
+ ...truct-libatomic_ops-we-do-require-CA.patch | 71 +++++++++++++++++++
+ ...ulator-reorder-inclued-headers-paths.patch | 49 +++++++++++++
+ ...3-erlang-enable-deterministic-builds.patch | 28 ++++++++
+ ...-update-df-call-to-work-with-Busybox.patch | 28 ++++++++
+ package/erlang/Config.in                      | 32 +++++++++
+ package/erlang/erlang.hash                    |  9 ++-
+ package/erlang/erlang.mk                      | 33 ++++++++-
+ 24 files changed, 938 insertions(+), 121 deletions(-)
  delete mode 100644 package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
  delete mode 100644 package/erlang/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/20.3.8.9/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
@@ -45,6 +49,10 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/23.3.4/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/23.3.4/0003-erlang-enable-deterministic-builds.patch
  create mode 100644 package/erlang/23.3.4/0004-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/24.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+ create mode 100644 package/erlang/24.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/24.0.2/0003-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/24.0.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -957,17 +965,217 @@ index 0000000000..9f98c4ad82
 +-- 
 +2.20.1
 +
+diff --git a/package/erlang/24.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/24.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+new file mode 100644
+index 0000000000..c5d83b2b36
+--- /dev/null
++++ b/package/erlang/24.0.2/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
+@@ -0,0 +1,71 @@
++From 2400947f3af66fbf39be86719ed03b1867d1423e Mon Sep 17 00:00:00 2001
++From: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Date: Sun, 28 Dec 2014 23:39:40 +0100
++Subject: [PATCH] erts/ethread: instruct libatomic_ops we do require CAS
++
++We do require compare-and-swap (CAS), so we must instruct libatomic_ops
++to provide it, even if the architecture does not have instructions for
++it.
++
++For example, on ARM, LDREX is required for fast CAS. But LDREX is only
++available on ARMv6, so by default libatomic_ops will not have CAS for
++anything below, like ARMv5. But ARMv5 is always UP, so using an
++emulated CAS (that is signal-asyn-safe) is still possible (albeit much
++slower).
++
++Tell libatomic_ops to provide CAS, even if the hardware is not capable
++of it, by using emulated CAS, as per libatomic_ops dosc:
++    https://github.com/ivmai/libatomic_ops/blob/master/doc/README.txt#L28
++
++    If this is included after defining AO_REQUIRE_CAS, then the package
++    will make an attempt to emulate compare-and-swap in a way that (at
++    least on Linux) should still be async-signal-safe.
++
++Thanks go to Thomas for all this insight! :-)
++Thanks go to Frank for reporting the issue! :-)
++
++Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
++Cc: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
++Cc: Frank Hunleth <fhunleth@troodon-software.com>
++---
++ erts/aclocal.m4                               | 4 +++-
++ erts/include/internal/libatomic_ops/ethread.h | 1 +
++ 2 files changed, 4 insertions(+), 1 deletion(-)
++
++diff --git a/erts/aclocal.m4 b/erts/aclocal.m4
++index 8317e3b10e..3063a80c5c 100644
++--- a/erts/aclocal.m4
+++++ b/erts/aclocal.m4
++@@ -2019,7 +2019,8 @@ case "$THR_LIB_NAME" in
++ 	    	    fi;;
++ 	    esac
++ 	    ethr_have_libatomic_ops=no
++-	    AC_TRY_LINK([#include "atomic_ops.h"],
+++	    AC_TRY_LINK([#define AO_REQUIRE_CAS
+++                    #include "atomic_ops.h"],
++ 	    	        [
++ 	    	    	    volatile AO_t x;
++ 	    	    	    AO_t y;
++@@ -2060,6 +2061,7 @@ case "$THR_LIB_NAME" in
++ 	        AC_CHECK_SIZEOF(AO_t, ,
++ 	    	    	        [
++ 	    	    	    	    #include <stdio.h>
+++	    	    	    	    #define AO_REQUIRE_CAS
++ 	    	    	    	    #include "atomic_ops.h"
++ 	    	    	        ])
++ 	        AC_DEFINE_UNQUOTED(ETHR_SIZEOF_AO_T, $ac_cv_sizeof_AO_t, [Define to the size of AO_t if libatomic_ops is used])
++diff --git a/erts/include/internal/libatomic_ops/ethread.h b/erts/include/internal/libatomic_ops/ethread.h
++index 4adc31ed2a..18cc22a8ad 100644
++--- a/erts/include/internal/libatomic_ops/ethread.h
+++++ b/erts/include/internal/libatomic_ops/ethread.h
++@@ -36,6 +36,7 @@
++ 
++ #define ETHR_NATIVE_IMPL__ "libatomic_ops"
++ 
+++#define AO_REQUIRE_CAS
++ #include "atomic_ops.h"
++ #include "ethr_membar.h"
++ #include "ethr_atomic.h"
++-- 
++2.25.1
++
+diff --git a/package/erlang/24.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/24.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+new file mode 100644
+index 0000000000..e7106f71ee
+--- /dev/null
++++ b/package/erlang/24.0.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
+@@ -0,0 +1,49 @@
++From 4c86188d052cd6150d171dec003523a85fdfef91 Mon Sep 17 00:00:00 2001
++From: Romain Naour <romain.naour@openwide.fr>
++Date: Sun, 8 Feb 2015 17:23:13 +0100
++Subject: [PATCH] erts/emulator: reorder inclued headers paths
++
++If the Perl Compatible Regular Expressions is installed on the
++host and the path to the headers is added to the CFLAGS, the
++pcre.h from the host is used instead of the one provided by
++erlang.
++
++Erlang use an old version of this file which is incompatible
++with the upstream one.
++
++Move INCLUDES before CFLAGS to use pcre.h from erlang.
++
++http://autobuild.buildroot.net/results/cbd/cbd8b54eef535f19d7d400fd269af1b3571d6143/build-end.log
++
++Signed-off-by: Romain Naour <romain.naour@openwide.fr>
++[Bernd: rebased for erlang-21.0]
++Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
++---
++ erts/emulator/Makefile.in | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/erts/emulator/Makefile.in b/erts/emulator/Makefile.in
++index c3449c5f73..8e1c323ad8 100644
++--- a/erts/emulator/Makefile.in
+++++ b/erts/emulator/Makefile.in
++@@ -800,7 +800,7 @@ endif
++ # Usually the same as the default rule, but certain platforms (e.g. win32) mix
++ # different compilers
++ $(OBJDIR)/beam_emu.o: beam/emu/beam_emu.c
++-	$(V_EMU_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_EMU_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ 
++ $(OBJDIR)/beam_emu.S: beam/emu/beam_emu.c
++ 	$(V_EMU_CC) -S -fverbose-asm $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++@@ -863,7 +863,7 @@ endif
++ # General targets
++ #
++ $(OBJDIR)/%.o: beam/%.c
++-	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
+++	$(V_CC) $(INCLUDES) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) -c $< -o $@
++ 
++ $(OBJDIR)/%.o: beam/emu/%.c
++ 	$(V_CC) $(subst -O2, $(GEN_OPT_FLGS), $(CFLAGS)) $(INCLUDES) -c $< -o $@
++-- 
++2.25.1
++
+diff --git a/package/erlang/24.0.2/0003-erlang-enable-deterministic-builds.patch b/package/erlang/24.0.2/0003-erlang-enable-deterministic-builds.patch
+new file mode 100644
+index 0000000000..0cfc5894dc
+--- /dev/null
++++ b/package/erlang/24.0.2/0003-erlang-enable-deterministic-builds.patch
+@@ -0,0 +1,28 @@
++From 70a045ba5286716bf1d4078d9a5adb061649d6ec Mon Sep 17 00:00:00 2001
++From: Frank Hunleth <fhunleth@troodon-software.com>
++Date: Thu, 21 Mar 2019 20:49:54 -0400
++Subject: [PATCH] erlang: enable deterministic builds
++
++This adds the `+deterministic` compiler flag to the `erlc` calls to
++strip out absolute paths in compiled `.beam` files.
++
++Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
++---
++ make/otp.mk.in | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/make/otp.mk.in b/make/otp.mk.in
++index 85bc49d2b0..312f358cf8 100644
++--- a/make/otp.mk.in
+++++ b/make/otp.mk.in
++@@ -109,6 +109,7 @@ ifeq ($(USE_ESOCK),yes)
++ ERL_COMPILE_FLAGS += -DUSE_ESOCK=true
++ endif
++ 
+++ERL_COMPILE_FLAGS += +deterministic
++ ERLC_WFLAGS = -W
++ ERLC = erlc $(ERLC_WFLAGS) $(ERLC_FLAGS)
++ ERL = erl -boot start_clean
++-- 
++2.25.1
++
+diff --git a/package/erlang/24.0.2/0004-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/24.0.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
+new file mode 100644
+index 0000000000..beb1957d46
+--- /dev/null
++++ b/package/erlang/24.0.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
+@@ -0,0 +1,28 @@
++From c7d4172745f7a0fdafeaafc2166f0db74e99a870 Mon Sep 17 00:00:00 2001
++From: Frank Hunleth <fhunleth@troodon-software.com>
++Date: Tue, 5 May 2020 21:19:01 -0400
++Subject: [PATCH] disksup: update df call to work with Busybox
++
++Busybox's df doesn't support `-x` and `-l` and this removes those
++options. Plus SquashFS filesystems are nice to view on Nerves so we
++don't want to exclude them anyway.
++---
++ lib/os_mon/src/disksup.erl | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/lib/os_mon/src/disksup.erl b/lib/os_mon/src/disksup.erl
++index b85b7c854a..a83f2daad8 100644
++--- a/lib/os_mon/src/disksup.erl
+++++ b/lib/os_mon/src/disksup.erl
++@@ -256,7 +256,7 @@ check_disk_space({unix, irix}, Port, Threshold) ->
++     check_disks_irix(skip_to_eol(Result), Threshold);
++ check_disk_space({unix, linux}, Port, Threshold) ->
++     Df = find_cmd("df", "/bin"),
++-    Result = my_cmd(Df ++ " -lk -x squashfs", Port),
+++    Result = my_cmd(Df ++ " -k", Port),
++     check_disks_solaris(skip_to_eol(Result), Threshold);
++ check_disk_space({unix, posix}, Port, Threshold) ->
++     Result = my_cmd("df -k -P", Port),
++-- 
++2.25.1
++
 diff --git a/package/erlang/Config.in b/package/erlang/Config.in
-index ab87eab6ff..17b97bed3d 100644
+index ab87eab6ff..c174dd3a74 100644
 --- a/package/erlang/Config.in
 +++ b/package/erlang/Config.in
-@@ -36,6 +36,33 @@ config BR2_PACKAGE_ERLANG
+@@ -36,6 +36,38 @@ config BR2_PACKAGE_ERLANG
  
  if BR2_PACKAGE_ERLANG
  
 +choice
 +	bool "Erlang/OTP version"
-+	default BR2_PACKAGE_ERLANG_23
++	default BR2_PACKAGE_ERLANG_24
 +	help
 +	  Select the Erlang/OTP version
 +
@@ -989,31 +1197,37 @@ index ab87eab6ff..17b97bed3d 100644
 +config BR2_PACKAGE_ERLANG_23
 +	bool "Erlang/OTP 23"
 +	help
-+	  Use the latest Erlang/OTP 23 release
++	  Use Erlang/OTP 23 (release may not include latest patches)
++
++config BR2_PACKAGE_ERLANG_24
++	bool "Erlang/OTP 24"
++	help
++	  Use the latest Erlang/OTP 24 release
 +endchoice
 +
  config BR2_PACKAGE_ERLANG_MEGACO
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 3c2f039496..d7de970aeb 100644
+index 3c2f039496..e7a0a55939 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
-@@ -1,4 +1,6 @@
+@@ -1,4 +1,7 @@
 -# md5 from http://www.erlang.org/download/MD5, sha256 locally computed
 -md5 b2b48dad6e69c1e882843edbf2abcfd3  otp_src_22.2.tar.gz
 -sha256 89c2480cdac566065577c82704a48e10f89cf2e6ca5ab99e1cf80027784c678f  otp_src_22.2.tar.gz
 +# sha256 locally computed
++sha256 4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18  OTP-24.0.2.tar.gz
 +sha256 adc937319227774d53f941f25fa31990f5f89a530f6cb5511d5ea609f9f18ebe  OTP-23.3.4.tar.gz
 +sha256 12d628c2d0bdc0cf1f1ec56bd3c4da697510b25ab744d45872f63fefdd1a7680  OTP-22.3.4.1.tar.gz
 +sha256 a5d558cb189e026cd45114ffa9bb52752945e7e450c6e7e396b2e626e5fffcc8  OTP-21.3.8.4.tar.gz
 +sha256 897dd8b66c901bfbce09ed64e0245256aca9e6e9bdf78c36954b9b7117192519  OTP-20.3.8.9.tar.gz
  sha256 809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 08589c3f60..23ceab27a1 100644
+index 08589c3f60..de0078cd01 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
-@@ -5,7 +5,20 @@
+@@ -5,7 +5,24 @@
  ################################################################################
  
  # See note below when updating Erlang
@@ -1027,7 +1241,11 @@ index 08589c3f60..23ceab27a1 100644
 +ifeq ($(BR2_PACKAGE_ERLANG_22),y)
 +ERLANG_VERSION = 22.3.4.1
 +else
++ifeq ($(BR2_PACKAGE_ERLANG_23),y)
 +ERLANG_VERSION = 23.3.4
++else
++ERLANG_VERSION = 24.0.2
++endif
 +endif
 +endif
 +endif
@@ -1035,7 +1253,7 @@ index 08589c3f60..23ceab27a1 100644
  ERLANG_SITE = https://github.com/erlang/otp/archive
  ERLANG_SOURCE = OTP-$(ERLANG_VERSION).tar.gz
  
-@@ -33,7 +46,19 @@ HOST_ERLANG_PRE_CONFIGURE_HOOKS += ERLANG_RUN_AUTOCONF
+@@ -33,7 +50,19 @@ HOST_ERLANG_PRE_CONFIGURE_HOOKS += ERLANG_RUN_AUTOCONF
  
  # Whenever updating Erlang, this value should be updated as well, to the
  # value of EI_VSN in the file lib/erl_interface/vsn.mk

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/erlang:23.3.4-ubuntu-focal-20210325
+FROM hexpm/erlang:24.0.2-ubuntu-focal-20210325
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
 description="Container with everything needed to build Nerves Systems"


### PR DESCRIPTION
This bumps Erlang from 23.3.4 to 24.0.2. See
https://erlang.org/download/OTP-24.0.README,
https://erlang.org/download/OTP-24.0.1.README, and
https://erlang.org/download/OTP-24.0.2.README.
