### PR TITLE
erlang: enable RISC-V builds

### DIFF
--- a/patches/buildroot/0013-erlang-add-RISC-V-to-the-supported-architectures.patch
+++ b/patches/buildroot/0013-erlang-add-RISC-V-to-the-supported-architectures.patch
@@ -1,0 +1,26 @@
+From 1e153ba30b93991a783e3884016b8cd2fbb15a36 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Thu, 29 Apr 2021 13:45:33 -0400
+Subject: [PATCH] erlang: add RISC-V to the supported architectures
+
+Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
+---
+ package/erlang/Config.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package/erlang/Config.in b/package/erlang/Config.in
+index c174dd3a74..9a43364800 100644
+--- a/package/erlang/Config.in
++++ b/package/erlang/Config.in
+@@ -8,7 +8,7 @@ config BR2_PACKAGE_ERLANG_ARCH_SUPPORTS
+ 	# see HOWTO/INSTALL.md for Erlang's supported platforms
+ 	# when using its native atomic ops implementation
+ 	default y if BR2_i386 || BR2_x86_64 || BR2_powerpc || \
+-		BR2_sparc_v9 || BR2_arm || BR2_aarch64 || BR2_mipsel
++		BR2_sparc_v9 || BR2_arm || BR2_aarch64 || BR2_mipsel || BR2_riscv
+ 	# erlang needs host-erlang
+ 	depends on BR2_PACKAGE_HOST_ERLANG_ARCH_SUPPORTS
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Erlang runs on RISC-V, but it needs to be enabled in Buildroot. This
enables it.
