### PR TITLE
erlinit: bump to v1.10.0

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 38f58b301a54ed664b223dec5f5f0633446fbe96663abf1c4c5629a058159c0c  erlinit-v1.9.0.tar.gz
+sha256 a774d2427bc6414d5aca103362170c870158b43aa9ec63d00d90e55ae9dabf86  erlinit-v1.10.0.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.9.0
+ERLINIT_VERSION = v1.10.0
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
See https://github.com/nerves-project/erlinit/releases/tag/v1.10.0
