### PR TITLE
Allow systems to be built on ARM 64 Linux

### DIFF
--- a/create-build.sh
+++ b/create-build.sh
@@ -62,7 +62,7 @@ if [[ $HOST_OS != "Linux" ]]; then
     exit 1
 fi
 
-if [[ $HOST_ARCH != "x86_64" ]]; then
+if [[ $HOST_ARCH != "x86_64" ]] && [[ $HOST_ARCH != "aarch64" ]]; then
     echo "ERROR: 64-bit Linux required for running cross-compilers built by nerves-toolchain"
     exit 1
 fi


### PR DESCRIPTION
Running on ARM 64 bit Linux I am getting the error `ERROR: 64-bit Linux required for running cross-compilers built by nerves-toolchain`. Updates the check to include ARM 64 linux.