### PR TITLE
Optionally include SBOM info in system artifacts

### DIFF
--- a/scripts/mksystem.sh
+++ b/scripts/mksystem.sh
@@ -78,6 +78,18 @@ cp "$BASE_DIR/.config" "$WORK_DIR/$ARCHIVE_NAME"
 cp -R "$BASE_DIR/images" "$WORK_DIR/$ARCHIVE_NAME"
 cp -HR "$BASE_DIR/staging" "$WORK_DIR/$ARCHIVE_NAME"
 
+# Copy SBOM information if generated
+if [[ -e "$BASE_DIR/pkg-stats.json" ]]; then
+    cp "$BASE_DIR/pkg-stats.json" "$WORK_DIR/$ARCHIVE_NAME"
+    cp "$BASE_DIR/pkg-stats.html" "$WORK_DIR/$ARCHIVE_NAME"
+fi
+if [[ -d "$BASE_DIR/legal-info" ]]; then
+    # The legal-info is very large since it contains all source tarballs.
+    # Don't include the source tarballs for now.
+    cp -R "$BASE_DIR/legal-info" "$WORK_DIR/$ARCHIVE_NAME"
+    rm -rf "$WORK_DIR/$ARCHIVE_NAME/legal-info/sources" "$WORK_DIR/$ARCHIVE_NAME/legal-info/host-sources"
+fi
+
 # Clean up extra files that were copied over and aren't needed
 rm -f "$WORK_DIR/$ARCHIVE_NAME/images"/*.fw
 rm -f "$WORK_DIR/$ARCHIVE_NAME/images/$ARCHIVE_NAME.img"


### PR DESCRIPTION
Buildroot has two tools for capturing SBOM-relevant information: `make
pkg-stats` and `make legal-info`. This makes it possible to add
`pkg-stats` and `legal-info` targets to the `make_opts` for your system
so that this info is captured. This is convenient so that you don't have
to rebuild a system to get the files when you need them. It also makes
it possible for tools to parse them and combine them with SBOM data from
the rest of your project.

The increase in system artifact size is minimal. Buildroot also includes
all of the source tarballs in its legal info, but that's like 800+ MB
for projects, so that's not included in this change.

