### PR TITLE
Dockerfile: add packages so make pkg-stats works

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -41,10 +41,13 @@ RUN apt-get install -y --no-install-recommends \
         locales \
         mercurial \
         python3 \
+        python3-aiohttp \
         python3-flake8 \
+        python3-ijson \
         python3-nose2 \
         python3-pexpect \
         python3-pip \
+        python3-requests \
         rsync \
         subversion \
         unzip \

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,7 +10,7 @@ run_test() {
     echo "Running $TEST"
     rm -fr "${TEST_OUTPUT:?}/$TEST"
     ../create-build.sh "$TEST_DIR/$TEST/nerves_defconfig" "$TEST_OUTPUT/$TEST"
-    make -C "$TEST_OUTPUT/$TEST"
+    make -C "$TEST_OUTPUT/$TEST" source all pkg-stats legal-info
     echo "$TEST succeeded"
 }
 


### PR DESCRIPTION
The pkg-stats target requires a few more packages so install those for
users building package stats with their system builds. Also add
`pkg-stats` and `legal-info` to the smoke test targets since they both
seem easy to miss changing package requirements since they're not
regularly tested..
