### PR TITLE
Add sysctl config file

### DIFF
--- a/board/nerves-common/rootfs_overlay/etc/sysctl.conf
+++ b/board/nerves-common/rootfs_overlay/etc/sysctl.conf
@@ -1,0 +1,2 @@
+# Allow all user groups to send a ping.
+net.ipv4.ping_group_range = 0 2147483647

--- a/board/nerves-common/rootfs_overlay/etc/sysctl.conf
+++ b/board/nerves-common/rootfs_overlay/etc/sysctl.conf
@@ -1,2 +1,9 @@
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# 
+# The variables in this file are loaded automatically at boot by nerves_runtime.
+# See sysctl.conf (5) for information on the file's format.
+#
+
 # Allow all user groups to send a ping.
 net.ipv4.ping_group_range = 0 2147483647


### PR DESCRIPTION
Related to elixir-toolshed/toolshed#81 and nerves-project/nerves_runtime#207

This PR adds a sysctl configuration file that allows all user groups to send an ICMP ping. Other params can be added to this config in the future, or it can be overridden by another rootfs overlay.

Out of the box on a Nerves target, `net.ipv4.ping_group_range` is set to `1 0` which causes an `:eacces` error when trying to open a socket to send an ICMP ping. This PR adjusts this parameter so that all users can send a ping.