### PR TITLE
Fix scrubbing files on MacOS

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -112,7 +112,16 @@ if [ -n "$NOSCRUBS" ]; then
     for NOSCRUB in $NOSCRUBS; do
         EXCLUSIONS+=( -not -path "${NOSCRUB/.noscrub/\*}" )
     done
-    EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
+
+    # For whatever reason, the `find` command below doesn't expand the
+    # exclusions on MacOS and so if you are attempting to skip scrubbing files,
+    # the task will fail. To get the proper variable expanded, we need to
+    # eval the call.
+    if [[ $(uname -s) == "Darwin" ]]; then
+        EXECUTABLES=$(eval find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
+    else
+        EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
+    fi
 else
     EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100)
 fi


### PR DESCRIPTION
For whatever reason, the `find` command doesn't expand the exclusions on MacOS and so if you are attempting to skip scrubbing files, the task will fail. To get the proper variable expanded, we need to `eval` the call.

But adding `eval` on any other system breaks the script. So, check the OS and decide which to do first.

I have no idea why MacOS won't expand and the only hints on the internet were to `eval` to force expansions first. I've confirmed this works in MacOS and Linux