### PR TITLE
erlinit: bump to v1.11.0

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 a774d2427bc6414d5aca103362170c870158b43aa9ec63d00d90e55ae9dabf86  erlinit-v1.10.0.tar.gz
+sha256 601c8c5d7a3ec0064235d6633a01b7bd4f93273eeb4384b30b44f177f00c4c1c  erlinit-v1.11.0.tar.gz
 sha256 c5f0dd61267232af733f4a4a9756d4edd21ab3cf3266cce597f0daff7be50e4a  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.10.0
+ERLINIT_VERSION = v1.11.0
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This brings in experimental support for adding a runtime.exs to perform
runtime configuration of the OTP release in the firmware build.
