### PR TITLE
Fix /bin/bash shebang to be /usr/bin/env bash

### DIFF
--- a/board/nerves-common/post-build.sh
+++ b/board/nerves-common/post-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Collect the build artifacts and put them in a directory
 # for Travis-CI to publish

--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Remove or minimize files in an Erlang/OTP release directory
 # in preparation for use packaging in a Nerves firmware image.

--- a/scripts/scrub-target.sh
+++ b/scripts/scrub-target.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/bin/test
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/bin/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SELF=$(readlink "$0" || true)

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/erl
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/erl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 SELF=$(readlink "$0" || true)
 if [ -z "$SELF" ]; then SELF="$0"; fi
 BINDIR="$(cd "$(dirname "$SELF")" && pwd -P)"

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/erl.src
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/erl.src
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # %CopyrightBegin%
 # 

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # %CopyrightBegin%
 # 

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start.src
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start.src
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # %CopyrightBegin%
 # 

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start_erl.src
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/erts-11.1.8/bin/start_erl.src
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 #
 # %CopyrightBegin%

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/elixir
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/elixir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/env.sh
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Sets and enables heart (recommended only in daemon mode)
 # case $RELEASE_COMMAND in

--- a/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/iex
+++ b/tests/smoke-test/rootfs_overlay/srv/erlang/releases/0.1.0/iex
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then

--- a/tests/smoke-test/run_scrubber.sh
+++ b/tests/smoke-test/run_scrubber.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 env
 

--- a/tests/smoke-test/verify.sh
+++ b/tests/smoke-test/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This wasn't a pull request initially because it took a minute for me to determine where this file came from on GitHub.  Using `/usr/bin/env` seems consistent with the other scripts here so opening as a pull request.

resolves [#650](https://github.com/nerves-project/nerves/issues/650)