### PR TITLE
Add changelog to hex package; remove maintainers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,8 @@ defmodule Nerves.System.BR.Mixfile do
 
   defp package do
     [
-      maintainers: ["Frank Hunleth", "Justin Schneck"],
       files: [
+        "CHANGELOG.md",
         "board",
         "package",
         "patches",


### PR DESCRIPTION
It's very convenient to see the changelog in the hex diffs, so add it
first to the package.

Also remove the maintainers since that's handled by hex.pm
automatically.
