### PR TITLE
fwup: work around GitHub URL change

### DIFF
--- a/patches/buildroot/0013-package-fwup-temp-workaround-for-GitHub-URL-change.patch
+++ b/patches/buildroot/0013-package-fwup-temp-workaround-for-GitHub-URL-change.patch
@@ -1,0 +1,40 @@
+From e421da9c211bad21b9ca959e87f7b4741c33aa30 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Sat, 27 Nov 2021 21:32:53 -0500
+Subject: [PATCH] package/fwup: temp workaround for GitHub URL change
+
+This works around a recent change to GitHub URLs that breaks fwup. It
+also breaks other packages, but they can be downloaded from Buildroot's
+cache.
+---
+ package/fwup/fwup.hash | 3 ++-
+ package/fwup/fwup.mk   | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/package/fwup/fwup.hash b/package/fwup/fwup.hash
+index 2e5b2b1f6c..1d24095d26 100644
+--- a/package/fwup/fwup.hash
++++ b/package/fwup/fwup.hash
+@@ -1,3 +1,4 @@
+ # Locally calculated
+-sha256  18ae6753145cef2fd5f5fc83e29c2d883e570668d8aa064ee6c94d4c5e44d73d  fwup-1.9.0.tar.gz
++sha256  18ae6753145cef2fd5f5fc83e29c2d883e570668d8aa064ee6c94d4c5e44d73d  v1.9.0.tar.gz
++sha256  ea07aed5ff07678a687d047f99235fa2cd5d9527ed58c10bc87799dbf8833dff  fwup-1.9.0.tar.gz
+ sha256  cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  LICENSE
+diff --git a/package/fwup/fwup.mk b/package/fwup/fwup.mk
+index 62016d94e3..09a4607efc 100644
+--- a/package/fwup/fwup.mk
++++ b/package/fwup/fwup.mk
+@@ -5,7 +5,8 @@
+ ################################################################################
+ 
+ FWUP_VERSION = 1.9.0
+-FWUP_SITE = $(call github,fwup-home,fwup,v$(FWUP_VERSION))
++FWUP_SITE = https://github.com/fwup-home/fwup/archive/refs/tags
++FWUP_SOURCE = v$(FWUP_VERSION).tar.gz
+ FWUP_LICENSE = Apache-2.0
+ FWUP_LICENSE_FILES = LICENSE
+ FWUP_DEPENDENCIES = host-pkgconf libconfuse libarchive
+-- 
+2.25.1
+


### PR DESCRIPTION
This is a temporary patch to work around the GitHub URL change which
brok the download. Once we update to a version of Buildroot with the
GitHub URL fix, this patch should be removed.
