### PR TITLE
Bump RPi WiFi firmware

### DIFF
--- a/package/rpi-distro-firmware-nonfree/Config.in
+++ b/package/rpi-distro-firmware-nonfree/Config.in
@@ -8,7 +8,7 @@ config BR2_PACKAGE_RPI_DISTRO_FIRMWARE_NONFREE
 
 	  Firmware binaries that ship with the Raspberry Pi OS
 
-	  https://github.com/raspberrypi/firmware
+	  https://github.com/RPi-Distro/firmware-nonfree
 
 comment "rpi-distro-firmware-nonfree conflicts with linux-firmware Broadcom BRCM bcm43xx and rpi-wifi-firmware"
 	depends on BR2_PACKAGE_LINUX_FIRMWARE_BRCM_BCM43XXX || BR2_PACKAGE_RPI_WIFI_FIRMWARE

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,5 +1,5 @@
 # Locally computed
-sha256  f8b3af1f394d7a820871d03ac0e7c58ebc1bd556812f4a27cd48eef330c57b00  rpi-distro-firmware-nonfree-83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5.tar.gz
+sha256  b7d9378e95db9d38a56572cc7004449cbcbb4c0cd8a36b64b89b1fa270067512  rpi-distro-firmware-nonfree-99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc.tar.gz
 sha256  8116433f4004fc0c24d72b3d9e497808b724aa0e5e1cd63fc1bf66b715b1e2e9  LICENCE.Abilis
 sha256  69f29eee4ad020ef08c469bddd68b565edce7adad627f93ad329ef9198a9e9f9  LICENCE.adsp_sst
 sha256  33a25775e426c44cfa5b8bd9dfa0c1dae7de0a90358a7b8f7054023189f1e0e0  LICENCE.agere

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,13 +4,13 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 83938f78ca2d5a0ffe0c223bb96d72ccc7b71ca5 # 1:20190114-1+rpt11 release
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc # 20210315-3+rpt4 release
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = LICENCE.broadcom_bcm43xx LICENCE.cypress
 
 define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm
-	for f in  $(@D)/brcm/*; do \
+	for f in  $(@D)/debian/config/brcm80211/brcm/*; do \
 		$(INSTALL) -D -m 0644 "$${f}" "$(TARGET_DIR)/lib/firmware/brcm/$${f##*/}" || exit 1; \
 	done
 endef


### PR DESCRIPTION
See https://github.com/RPi-Distro/firmware-nonfree/blob/bullseye/debian/changelog
for all of the changes.


