### PR TITLE
export `CMAKE_TOOLCHAIN_FILE` for downstream libraries which use CMake

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Nerves.System.BR.Mixfile do
         "mix.exs",
         "nerves_env.exs",
         "nerves-env.sh",
+        "nerves-env.cmake",
         "nerves.mk",
         "README.md",
         "VERSION"

--- a/nerves-env.cmake
+++ b/nerves-env.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.9 FATAL_ERROR)
-
 set(CMAKE_SYSTEM "Linux")
 set(CMAKE_SYSTEM_NAME "Linux")
 

--- a/nerves-env.cmake
+++ b/nerves-env.cmake
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.9 FATAL_ERROR)
+
+set(CMAKE_SYSTEM "Linux")
+set(CMAKE_SYSTEM_NAME "Linux")
+
+# set nerves sysroot
+set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_SYSROOT}")
+
+# adjust the default behavior of the find commands:
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+
+# never search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/nerves-env.cmake
+++ b/nerves-env.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM "Linux")
 set(CMAKE_SYSTEM_NAME "Linux")
 
 # set nerves sysroot
-set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_SYSROOT}")
+set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_ROOTFS}")
 
 # adjust the default behavior of the find commands:
 # search headers and libraries in the target environment

--- a/nerves-env.cmake
+++ b/nerves-env.cmake
@@ -2,7 +2,7 @@ set(CMAKE_SYSTEM "Linux")
 set(CMAKE_SYSTEM_NAME "Linux")
 
 # set nerves sysroot
-set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_ROOTFS}")
+set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_SYSROOT}")
 
 # adjust the default behavior of the find commands:
 # search headers and libraries in the target environment

--- a/nerves_env.exs
+++ b/nerves_env.exs
@@ -81,6 +81,8 @@ sdk_sysroot = Path.join(system_path, "staging")
     Path.join(toolchain_path, "bin")
     |> System.Env.path_add()
 
+    System.put_env("CMAKE_TOOLCHAIN_FILE", Path.expand(Path.join(__DIR__, "nerves-env.cmake")))
+
     {toolchain_path, crosscompile}
   end
 

--- a/nerves_env.exs
+++ b/nerves_env.exs
@@ -86,30 +86,7 @@ sdk_sysroot = Path.join(system_path, "staging")
     {toolchain_path, crosscompile}
   end
 
-nerves_images = Path.join(system_path, "images")
-nerves_rootfs = Path.join([nerves_images, "rootfs"])
-nerves_rootfs_squashfs = Path.join([nerves_images, "rootfs.squashfs"])
-
-with {:has_rootfs, false} <- {:has_rootfs, File.dir?(rootfs)},
-     {:has_unsquashfs, true} <-
-       {:has_unsquashfs, not is_nil(System.find_executable("unsquashfs"))},
-     {:unsquashfs, {_, 0}} <-
-       {:unsquashfs, System.cmd("unsquashfs", ["-f", "-d", rootfs, rootfs_squashfs])} do
-  nil
-else
-  {:has_rootfs, true} ->
-    nil
-
-  {:has_unsquashfs, false} ->
-    Mix.raise("ERROR: Please install unsquashfs first")
-
-  {:unsquashfs, error} ->
-    IO.inspect(error)
-    Mix.raise("ERROR: unsquashfs failed")
-end
-
-System.put_env("NERVES_SDK_ROOTFS", nerves_rootfs)
-System.put_env("NERVES_SDK_IMAGES", nerves_images)
+System.put_env("NERVES_SDK_IMAGES", Path.join(system_path, "images"))
 System.put_env("NERVES_SDK_SYSROOT", sdk_sysroot)
 
 system_include_path =


### PR DESCRIPTION
Hi, this PR adds a basic CMake toolchain file for cross-compiling environment and the path to the toolchain file is exported to a system environment variable `CMAKE_TOOLCHAIN_FILE`. 

This allows downstream libraries which use CMake to find the correct sysroot, and prevent CMake to search system libraries in the host environment.

The downstream libraries can decide whether they want to use the provided toolchain file. If yes, then they can append `-D CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}` to their CMake options.

For example, before applying this patch, CMake will search libraries available on the host, which causes the linker to try to link the NIF shared library to libraries on the host, and this can result in either

- a fatal error, when the host's architecture is different from the `MIX_TARGET`
- successfully compiled (when host and `MIX_TARGET` have the same CPU architecture), but the libraries linked were never copied to the firmware, the final program cannot load the library and lead to infinite reboots

#### before
```
==> nerves
==> nerves_project

Nerves environment
  MIX_TARGET:   rpi0
  MIX_ENV:      dev

... skipped ...

--   Media I/O:
--     ZLib:                        zlib (ver 1.2.11) <= library on x86_64 host, yet the target is armv6
--     JPEG:                        libjpeg-turbo (ver 2.1.0-62)
--     WEBP:                        /usr/local/lib/libwebp.a (ver encoder: 0x0210) <= library on x86_64 host, yet the target is armv6
--     PNG:                         build (ver 1.6.37)
--     TIFF:                        build (ver 42 - 4.2.0)
--     JPEG 2000:                   OpenJPEG (ver 2.4.0)
--     HDR:                         YES
--     SUNRASTER:                   YES
--     PXM:                         YES
--     PFM:                         YES
...
```

#### after
```
==> nerves
==> nerves_project

Nerves environment
  MIX_TARGET:   rpi0
  MIX_ENV:      dev

... skipped ...

--   Media I/O:
--     ZLib:                        /Users/cocoa/.nerves/artifacts/nerves_system_rpi0-portable-1.18.0/staging/usr/lib/libz.so (ver 1.2.11) <= use library in sysroot, ok
--     JPEG:                        libjpeg-turbo (ver 2.1.0-62)
--     WEBP:                        build (ver encoder: 0x020f) <= build library for armv6, ok
--     PNG:                         build (ver 1.6.37)
--     TIFF:                        build (ver 42 - 4.2.0)
--     JPEG 2000:                   OpenJPEG (ver 2.4.0)
--     HDR:                         YES
--     SUNRASTER:                   YES
--     PXM:                         YES
--     PFM:                         YES
...
```

Signed-off-by: Cocoa <89497197+cocoa-xu@users.noreply.github.com>