### PR TITLE
Bump Erlang versions for Docker image

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 24.2
+erlang 24.2.1

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/erlang:24.2-ubuntu-focal-20210325
+FROM hexpm/erlang:24.2.1-ubuntu-focal-20210325
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
 description="Container with everything needed to build Nerves Systems"

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/erlang:24.2.1-ubuntu-focal-20210325
+FROM hexpm/erlang:24.2.1-ubuntu-focal-20211006
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
 description="Container with everything needed to build Nerves Systems"


### PR DESCRIPTION
When updating to OTP 24.2.1, these updates were missed. Luckily, it
doesn't look like there's a meaningful different with 24.2, but they
should match anyway.
