### PR TITLE
bborg-overlays: support changing overlay paths

### DIFF
--- a/package/bborg-overlays/Config.in
+++ b/package/bborg-overlays/Config.in
@@ -5,3 +5,13 @@ config BR2_PACKAGE_BBORG_OVERLAYS
 	  Device Tree Overlays for bb.org boards
 
 	  https://github.com/beagleboard/bb.org-overlays
+
+if BR2_PACKAGE_BBORG_OVERLAYS
+
+config BR2_PACKAGE_BBORG_INSTALL_PATH
+	string "Installation path"
+	default "/lib/firmware"
+	help
+	  Path on target for device tree overlay files
+
+endif # BR2_PACKAGE_BBORG_OVERLAYS

--- a/package/bborg-overlays/bborg-overlays.mk
+++ b/package/bborg-overlays/bborg-overlays.mk
@@ -19,8 +19,8 @@ define BBORG_OVERLAYS_BUILD_CMDS
 endef
 
 define BBORG_OVERLAYS_INSTALL_TARGET_CMDS
-	mkdir -p $(TARGET_DIR)/lib/firmware
-	cp $(@D)/src/arm/*.dtbo $(TARGET_DIR)/lib/firmware
+	mkdir -p $(TARGET_DIR)$(BR2_PACKAGE_BBORG_INSTALL_PATH)
+	cp $(@D)/src/arm/*.dtbo $(TARGET_DIR)$(BR2_PACKAGE_BBORG_INSTALL_PATH)
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Upstream Beagleboard now looks for overlays in `/boot/overlays` first.
It then tries `/lib/firmware` which is the directory that
`nerves_system_bbb` has always checked.

This lets systems modify the path if they're able to migrate to the new
location. The default is the still `/lib/firmware`.
