### PR TITLE
nerves_heart: support include_erts: true

### DIFF
--- a/package/nerves_heart/nerves_heart.mk
+++ b/package/nerves_heart/nerves_heart.mk
@@ -9,13 +9,20 @@ NERVES_HEART_SITE = $(call github,nerves-project,nerves_heart,$(NERVES_HEART_VER
 NERVES_HEART_LICENSE = MIT
 NERVES_HEART_LICENSE_FILES = LICENSE
 NERVES_HEART_DEPENDENCIES = erlang
+NERVES_HEART_INSTALL_STAGING = YES
 
 define NERVES_HEART_BUILD_CMDS
 	$(MAKE1) $(TARGET_CONFIGURE_OPTS) -C $(@D)
 endef
 
 define NERVES_HEART_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 755 $(@D)/heart $(TARGET_DIR)/usr/lib/erlang/erts-*/bin/heart
+	ERTS_BIN=$(ls $(TARGET_DIR)/usr/lib/erlang/erts-*/bin);\
+	if -e "$(ERTS_BIN)"; then $(INSTALL) -D -m 755 $(@D)/heart $(ERTS_BIN)/heart; fi
+endef
+
+define NERVES_HEART_INSTALL_STAGING_CMDS
+	ERTS_BIN=$(ls $(STAGING_DIR)/usr/lib/erlang/erts-*/bin);\
+	if -e "$(ERTS_BIN)"; then $(INSTALL) -D -m 755 $(@D)/heart $(ERTS_BIN)/heart; fi
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This installs `nerves_heart` to the staging directory so that it's
possible to use `include_erts: true` when making releases. Without this
change, the staging directory has the default version of Erlang's
`heart` that doesn't pet the hardware watchdog. That means that if you
use `include_erts: true` in your release (likely indirectly via the
Nerves tooling), then the device will reboot when the hardware watchdog
times out.
