### PR TITLE
Update RPi WiFi to 20210315-3+rpt5 + Zero 2W fix

### DIFF
--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  b7d9378e95db9d38a56572cc7004449cbcbb4c0cd8a36b64b89b1fa270067512  rpi-distro-firmware-nonfree-99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc.tar.gz
-sha256  920d95488570776d703f700d226e36faf7b156c63502797b23cfb4ac3791104f  debian/config/brcm80211/LICENSE
+sha256  ff010a5c657cfb5719bac68347cf2a448fa204c9d563245ffd0d48e9ae980bcf  rpi-distro-firmware-nonfree-4db8c5d80daf2220d7824cfa6052f0bb108612ea.tar.gz
+sha256  363fb52cb7a74719cc7eda2cf9ebe2984791b6aed70552900a08e8b3ba18833d  debian/config/brcm80211/copyright

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,9 +4,9 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc # 20210315-3+rpt4 release
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 4db8c5d80daf2220d7824cfa6052f0bb108612ea # 20210315-3+rpt5 + RPI Zero 2W update
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
-RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/config/brcm80211/LICENSE
+RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/config/brcm80211/copyright
 
 define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm


### PR DESCRIPTION
From the changelog:

* Add ability to choose between 43436 and 43436S using update-alternatives
* The shipping firmware for the SYN43436P does not support 4-way
  handshake offloading. This new firmware (version string "Version:
  9.88.4.77 CRC: 143f9f15 Date: Thu 2022-03-31 17:25:16 CST Ucode Ver:
  1043.20743 FWID: 01-3b307371") fixes that.
