### PR TITLE
rpi-distro-firmware-nonfree: add symlinks

### DIFF
--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -8,13 +8,17 @@ RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 4db8c5d80daf2220d7824cfa6052f0bb108612ea #
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/config/brcm80211/copyright
 
-# The brcmfmac43436f-sdio symlinks come from the firmware-brcm80211.postinst script
+# Notes
+# 1. The brcmfmac43436f-sdio symlinks come from the firmware-brcm80211.postinst script
+# 2. The cyfmac43455-sdio-minimal firmware isn't used. It's for increasing the number
+#    of supported clients in AP mode by removing functionality.
 define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
-	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm
-	for f in  $(@D)/debian/config/brcm80211/brcm/*; do \
-		$(INSTALL) -D -m 0644 "$${f}" "$(TARGET_DIR)/lib/firmware/brcm/$${f##*/}" || exit 1; \
-	done; \
-	ln -sf brcmfmac43436f-sdio.bin "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.bin"; \
+	mkdir -p "$(TARGET_DIR)/lib/firmware"
+	cp -dpfr "$(@D)/debian/config/brcm80211/brcm" "$(TARGET_DIR)/lib/firmware"
+	cp -dpfr "$(@D)/debian/config/brcm80211/cypress" "$(TARGET_DIR)/lib/firmware"
+	rm -f "$(TARGET_DIR)/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
+	rm -f "$(TARGET_DIR)/lib/firmware/cypress/README.txt"
+	ln -sf brcmfmac43436f-sdio.bin "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.bin"
 	ln -sf brcmfmac43436f-sdio.txt "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.txt"
 endef
 

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -8,11 +8,14 @@ RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 4db8c5d80daf2220d7824cfa6052f0bb108612ea #
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/config/brcm80211/copyright
 
+# The brcmfmac43436f-sdio symlinks come from the firmware-brcm80211.postinst script
 define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/brcm
 	for f in  $(@D)/debian/config/brcm80211/brcm/*; do \
 		$(INSTALL) -D -m 0644 "$${f}" "$(TARGET_DIR)/lib/firmware/brcm/$${f##*/}" || exit 1; \
-	done
+	done; \
+	ln -sf brcmfmac43436f-sdio.bin "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.bin"; \
+	ln -sf brcmfmac43436f-sdio.txt "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.txt"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
The rpi-distro-firmware-nonfree repository really is a Debian package
script. I had sync'ed the files and symlinks in the firmware directory,
but there were a couple that I missed in the Debian post install
script.

This fixes an issue where the Raspberry Pi Zero 2W's WiFi module's
firmware wouldn't load with Linux 5.15.
