### PR TITLE
set system processor

### DIFF
--- a/nerves-env.cmake
+++ b/nerves-env.cmake
@@ -4,6 +4,9 @@ set(CMAKE_SYSTEM_NAME "Linux")
 # set nerves sysroot
 set(CMAKE_FIND_ROOT_PATH "$ENV{NERVES_SDK_SYSROOT}")
 
+# set system processor
+set(CMAKE_SYSTEM_PROCESSOR "$ENV{TARGET_ARCH}")
+
 # adjust the default behavior of the find commands:
 # search headers and libraries in the target environment
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Set `CMAKE_SYSTEM_PROCESSOR` to `$ENV{TARGET_ARCH}`. 

Some libraries (e.g., xnnpack) (implicitly) require this variable to be set when cross-compiling.