### PR TITLE
Add nerves_system_grisp2 link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ supported hardware systems:
 * [Raspberry Pi 4 Model B](https://github.com/nerves-project/nerves_system_rpi4)
 * [OSD32MP1](https://github.com/nerves-project/nerves_system_osd32mp1)
 * [Generic x86_64](https://github.com/nerves-project/nerves_system_x86_64)
+* [GRiSP 2](https://github.com/nerves-project/nerves_system_grisp2)
 
 We only officially support easily obtained hardware, but that doesn't mean that
 Nerves only works on these boards. If it's possible to use Buildroot to create a


### PR DESCRIPTION
We now officially support GRiSP2, adding [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2).

In this repo [nerves_system_br](https://github.com/nerves-project/nerves_system_br), all we need seems to be just add a link to [nerves_system_grisp2](https://github.com/nerves-project/nerves_system_grisp2) in `README.md`.
