### PR TITLE
Enable aarch64 compatibility in the Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ docker_build: &docker_build
   run:
     name: Build docker images
     command: |
-      docker build -t $DOCKER_REPO:$DOCKER_TAG $DOCKER_PATH
+      docker buildx create --use
+      docker buildx build --platform linux/arm64,linux/amd64 $DOCKER_REPO:$DOCKER_TAG $DOCKER_PATH
 
 docker_save: &docker_save
   run:

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -5,13 +5,19 @@ description="Container with everything needed to build Nerves Systems"
 
 USER root
 
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV FWUP_VERSION=1.9.0
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 COPY docker-entrypoint.sh /nerves/docker-entrypoint.sh
+COPY setup-packages.sh /nerves/setup-packages.sh
+
 RUN chmod +x /nerves/docker-entrypoint.sh
+RUN chmod +x /nerves/setup-packages.sh
 
 # Set time
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
@@ -22,8 +28,16 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8 C.UTF-8/' /etc/locale.gen
     locale-gen
 
 # The container has no package lists, so need to update first
-RUN dpkg --add-architecture i386 && \
-    apt-get update -y -qq
+RUN /nerves/setup-packages.sh && apt-get update -y -qq
+
+# Install our i386 deps first, since they require special config in aarch64 envs
+RUN apt-get install -y \
+        libc6:i386 \
+        libncurses5:i386 \
+        gcc-multilib \
+        g++-multilib \
+        libstdc++6:i386
+
 # Install Buildroot packages (see <Buildroot>/support/docker/DockerFile
 RUN apt-get install -y --no-install-recommends \
         bc \
@@ -34,12 +48,11 @@ RUN apt-get install -y --no-install-recommends \
         cpio \
         cvs \
         file \
-        g++-multilib \
+        g++ \
         git \
-        libc6-i386 \
         libncurses5-dev \
         locales \
-        mercurial \
+        mercurial-common \
         python3 \
         python3-aiohttp \
         python3-flake8 \
@@ -52,25 +65,30 @@ RUN apt-get install -y --no-install-recommends \
         subversion \
         unzip \
         wget
-# Install additional packages for Nerves
+
+# Install additional packages for Nerves and fwup
 RUN apt-get install -y --no-install-recommends \
     bzip2 \
     curl \
     gawk \
-    gcc-multilib \
+    gcc \
     gnupg \
     gosu \
     jq \
     libmnl-dev \
-    libncurses5:i386 \
-    libstdc++6:i386 \
     libz-dev \
     libssl-dev \
     openssh-client \
     pkg-config \
     squashfs-tools \
     vim-tiny \
-    xz-utils
+    xz-utils \
+    autoconf \
+    automake \
+    libtool \
+    libarchive-dev \
+    libconfuse-dev
+
 RUN rm -rf /var/lib/apt/lists/* \
   && mkdir -p /root/.ssh \
   && ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts \
@@ -81,9 +99,8 @@ RUN rm -rf /var/lib/apt/lists/* \
   && apt-get -q -y clean \
   && mkdir -p /nerves/build && chmod 777 /nerves/build
 
-RUN wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb \
-  && dpkg -i fwup_${FWUP_VERSION}_amd64.deb \
-  && rm -f *.tar.gz \
-  && rm -f fwup_${FWUP_VERSION}_amd64.deb
+# Build fwup from source for the current architecture
+RUN git clone https://github.com/fwup-home/fwup -b v${FWUP_VERSION} && cd fwup && ./autogen.sh && ./configure && make && make install
+RUN rm -rf fwup
 
 ENTRYPOINT [ "/nerves/docker-entrypoint.sh" ]

--- a/support/docker/nerves_system_br/setup-packages.sh
+++ b/support/docker/nerves_system_br/setup-packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-if [[ $BUILD_ARCH =~ "aarch64" ]] ; then
+if [[ $TARGETPLATFORM =~ "linux/arm64" ]] ; then
     dpkg --add-architecture 'i386'
     sed 's/^deb http/deb [arch=arm64] http/' -i '/etc/apt/sources.list'
 

--- a/support/docker/nerves_system_br/setup-packages.sh
+++ b/support/docker/nerves_system_br/setup-packages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+if [[ $BUILD_ARCH =~ "aarch64" ]] ; then
+    dpkg --add-architecture 'i386'
+    sed 's/^deb http/deb [arch=arm64] http/' -i '/etc/apt/sources.list'
+
+    touch /etc/apt/sources.list.d/i386.list
+    echo "deb [arch=i386] http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
+    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy           main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
+    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-updates   main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
+    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
+else
+    dpkg --add-architecture i386
+fi


### PR DESCRIPTION
Currently I develop primarily on an M1 MacBook Pro - When it comes to building Nerves systems, it seems that there's only first class support for `x86_64`. 

This PR aims to introduce small changes to the Dockerfile and CI configuration that will enable `aarch64` host systems (such as M1 machines) to build Nerves systems using Docker. I've tested it on some internal system repositories with success.

* Enable multi-arch builds in CircleCI
* Modify `Dockerfile` to work with both targets (`linux/amd64` and `linux/arm64`)
* Add a `setup-packages.sh` script used during the Docker build to use the proper method of installing `i386` libraries for systems.

NOTE: To fully support `aarch64` host machines, we also need to enable `aarch64` Linux toolchains over at: https://github.com/nerves-project/toolchains in the releases. I've used Docker to build these successfully as well.