### PR TITLE
Revert libp11 to 0.4.11 to fix pkcs11 issue

### DIFF
--- a/patches/buildroot/0012-Revert-package-libp11-bump-to-version-0.4.12.patch
+++ b/patches/buildroot/0012-Revert-package-libp11-bump-to-version-0.4.12.patch
@@ -1,0 +1,70 @@
+From 9607914f50cff35205b6c3414de11296e0567c72 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Sun, 11 Sep 2022 08:18:28 -0400
+Subject: [PATCH] Revert "package/libp11: bump to version 0.4.12"
+
+This reverts commit ecf8efb292fb410ab8080891fb017d4a01ef3cd5.
+---
+ package/libp11/0001-Update-wp11_rsa.c.patch | 26 +++++++++++++++++++++
+ package/libp11/libp11.hash                  |  2 +-
+ package/libp11/libp11.mk                    |  2 +-
+ 3 files changed, 28 insertions(+), 2 deletions(-)
+ create mode 100644 package/libp11/0001-Update-wp11_rsa.c.patch
+
+diff --git a/package/libp11/0001-Update-wp11_rsa.c.patch b/package/libp11/0001-Update-wp11_rsa.c.patch
+new file mode 100644
+index 0000000000..0a2d6e65ce
+--- /dev/null
++++ b/package/libp11/0001-Update-wp11_rsa.c.patch
+@@ -0,0 +1,26 @@
++From 4968cfc64dbaa39bb479a24d9578d75099e2f337 Mon Sep 17 00:00:00 2001
++From: patchMonkey156 <pagorman@asu.edu>
++Date: Mon, 19 Oct 2020 17:12:15 -0400
++Subject: [PATCH] Update p11_rsa.c
++
++Bugfix for new LibreSSL version 3.2.2
++[Retrieved from:
++https://github.com/OpenSC/libp11/commit/4968cfc64dbaa39bb479a24d9578d75099e2f337]
++Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
++---
++ src/p11_rsa.c | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/src/p11_rsa.c b/src/p11_rsa.c
++index b6beef0..ff12ed7 100644
++--- a/src/p11_rsa.c
+++++ b/src/p11_rsa.c
++@@ -336,7 +336,7 @@ int pkcs11_get_key_size(PKCS11_KEY *key)
++ 	return RSA_size(rsa);
++ }
++ 
++-#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+++#if ( ( defined (OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER < 0x10100005L ) || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3020199L ) )
++ 
++ int (*RSA_meth_get_priv_enc(const RSA_METHOD *meth))
++ 		(int flen, const unsigned char *from,
+diff --git a/package/libp11/libp11.hash b/package/libp11/libp11.hash
+index 0e42bdd4cf..52d73d4206 100644
+--- a/package/libp11/libp11.hash
++++ b/package/libp11/libp11.hash
+@@ -1,3 +1,3 @@
+ # Locally computed:
+-sha256  1e1a2533b3fcc45fde4da64c9c00261b1047f14c3f911377ebd1b147b3321cfd  libp11-0.4.12.tar.gz
++sha256  57d47a12a76fd92664ae30032cf969284ebac1dfc25bf824999d74b016d51366  libp11-0.4.11.tar.gz
+ sha256  d80c9d084ebfb50ea1ed91bfbc2410d6ce542097a32c43b00781b83adcb8c77f  COPYING
+diff --git a/package/libp11/libp11.mk b/package/libp11/libp11.mk
+index 7718573ace..c1873a920c 100644
+--- a/package/libp11/libp11.mk
++++ b/package/libp11/libp11.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-LIBP11_VERSION = 0.4.12
++LIBP11_VERSION = 0.4.11
+ LIBP11_SITE = https://github.com/OpenSC/libp11/releases/download/libp11-$(LIBP11_VERSION)
+ LIBP11_DEPENDENCIES = openssl host-pkgconf
+ LIBP11_INSTALL_STAGING = YES
+-- 
+2.25.1
+


### PR DESCRIPTION
libp11 0.4.12 does not work with nerves_key_pkcs11 right now. It's
unclear when we'll figure this out at the moment, so revert the update
for now.
