### PR TITLE
Fixup shellchecks for nerves-env.sh

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -6,41 +6,42 @@
 # "readlink -f" implementation for BSD
 # This code was extracted from the Elixir shell scripts
 readlink_f () {
+    # shellcheck disable=SC2164
     cd "$(dirname "$1")" > /dev/null
     filename="$(basename "$1")"
     if [ -h "$filename" ]; then
         readlink_f "$(readlink "$filename")"
     else
-        echo "`pwd -P`/$filename"
+        echo "$(pwd -P)/$filename"
     fi
 }
 
 # If the script is called with the -get-nerves-root flag it just returns the
 # Nerves system directory. This is so that other shells can execute the script
 # without needing to implement the equivalent of $BASH_SOURCE for every shell.
-for arg in $*
+for arg in "$@"
 do
-    if [ $arg = "-get-nerves-root" ];
+    if [ "$arg" = "-get-nerves-root" ];
     then
-        echo $(dirname $(readlink_f "${BASH_SOURCE[0]}"))
+        dirname "$(readlink_f "${BASH_SOURCE[0]}")"
         exit 0
     fi
 done
 
-if [ "$BASH_SOURCE" = "" ]; then
-    GET_NR_COMMAND="$0 $@ -get-nerves-root"
+if [ "${BASH_SOURCE[0]}" = "" ]; then
+    GET_NR_COMMAND="$0 $* -get-nerves-root"
     SCRIPT_DIR=$(bash -c "$GET_NR_COMMAND")
 else
-    SCRIPT_DIR=$(dirname $(readlink_f "${BASH_SOURCE[0]}"))
+    SCRIPT_DIR=$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")
 fi
 
 # Detect if this script has been run directly rather than sourced, since
 # that won't work.
 if [[ "$SHELL" = "/bin/bash" ]]; then
-    if [ "$0" != "bash" -a "$0" != "-bash" -a "$0" != "/bin/bash" ]; then
+    if [[ "$1" != "bash" && "$1" != "-bash" && "$1" != "/bin/bash" ]]; then
         echo ERROR: This scripted should be sourced from bash:
         echo
-        echo source $BASH_SOURCE
+        echo source "${BASH_SOURCE[@]}"
         echo
         exit 1
     fi
@@ -63,15 +64,15 @@ else
     return 1
 fi
 
-source $SCRIPT_DIR/scripts/nerves-env-helper.sh $NERVES_SYSTEM
-if [ $? != 0 ]; then
+# shellcheck source=/dev/null
+if ! source "$SCRIPT_DIR/scripts/nerves-env-helper.sh" "$NERVES_SYSTEM"; then
     echo "Shell environment NOT updated for Nerves!"
     return 1
 else
     # Found it. Print out some useful information so that the user can
     # easily figure out whether the wrong nerves installation was used.
-    NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= $NERVES_SYSTEM/.config | sed -e 's/BR2_DEFCONFIG="\(.*\)"/\1/')
-    GCC_VERSION=$($CROSSCOMPILE-gcc --version | head -1)
+    NERVES_DEFCONFIG=$(grep BR2_DEFCONFIG= "$NERVES_SYSTEM"/.config | sed -e 's/BR2_DEFCONFIG="\(.*\)"/\1/')
+    GCC_VERSION=$("$CROSSCOMPILE"-gcc --version | head -1)
 
     echo "Shell environment updated for Nerves"
     echo


### PR DESCRIPTION
For #202 

* https://www.shellcheck.net/wiki/SC2046 - Quote this to prevent word splitting.
* https://www.shellcheck.net/wiki/SC2048 - Use "$@" (with quotes) to prevent whitespace problems.
* https://www.shellcheck.net/wiki/SC2124 - Assign as array, or use * instead of @ to concatenate.
* https://www.shellcheck.net/wiki/SC2166 - `-a` is not well defined
* https://www.shellcheck.net/wiki/SC2128 - Expanding an array without an index only gives the first element.
* https://www.shellcheck.net/wiki/SC2086 - Double quote to prevent globbing and word splitting.
* https://www.shellcheck.net/wiki/SC2181 - Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.