### PR TITLE
Fix shellcheck for scrub-otp-release.sh

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -115,6 +115,7 @@ if [ -n "$NOSCRUBS" ]; then
     # the task will fail. To get the proper variable expanded, we need to
     # eval the call.
     if [[ $(uname -s) == "Darwin" ]]; then
+        # shellcheck disable=SC2294
         EXECUTABLES=$(eval find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
     else
         EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")


### PR DESCRIPTION
* https://www.shellcheck.net/wiki/SC2294 - eval negates the benefit of array

This actually disables that check since it is only for MacOS and this seems to be the only way I can get the scrubbing to work