### PR TITLE
Fix shellcheck for setup-packages.sh

### DIFF
--- a/support/docker/nerves_system_br/setup-packages.sh
+++ b/support/docker/nerves_system_br/setup-packages.sh
@@ -5,10 +5,12 @@ if [[ $TARGETPLATFORM =~ "linux/arm64" ]] ; then
     sed 's/^deb http/deb [arch=arm64] http/' -i '/etc/apt/sources.list'
 
     touch /etc/apt/sources.list.d/i386.list
-    echo "deb [arch=i386] http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
-    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy           main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
-    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-updates   main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
-    echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list.d/i386.list
+    {
+        echo "deb [arch=i386] http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse"
+        echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy           main restricted universe multiverse"
+        echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-updates   main restricted universe multiverse"
+        echo "deb [arch=i386] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse"
+    } >> /etc/apt/sources.list.d/i386.list
 else
     dpkg --add-architecture i386
 fi


### PR DESCRIPTION
For #202

* https://www.shellcheck.net/wiki/SC2129 - Consider using { cmd1; cmd2; } >> file instead of individual redirects.