### PR TITLE
erlang: bump to 25.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 25.0.4
+erlang 25.1

--- a/patches/buildroot/0007-erlang-support-OTP-21-25.patch
+++ b/patches/buildroot/0007-erlang-support-OTP-21-25.patch
@@ -1,4 +1,4 @@
-From a389450c0b4ada5662d687bd1c4a82f8cc1450cc Mon Sep 17 00:00:00 2001
+From dbe26c43613806f214f7b65cb80355bf994e82bc Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 21 - 25
@@ -50,9 +50,9 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/24.3.2/0002-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/24.3.2/0003-erlang-enable-deterministic-builds.patch
  create mode 100644 package/erlang/24.3.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
- create mode 100644 package/erlang/25.0.4/0001-erts-emulator-reorder-inclued-headers-paths.patch
- create mode 100644 package/erlang/25.0.4/0002-erlang-enable-deterministic-builds.patch
- create mode 100644 package/erlang/25.0.4/0003-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/25.1/0001-erts-emulator-reorder-inclued-headers-paths.patch
+ create mode 100644 package/erlang/25.1/0002-erlang-enable-deterministic-builds.patch
+ create mode 100644 package/erlang/25.1/0003-disksup-update-df-call-to-work-with-Busybox.patch
 
 diff --git a/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 deleted file mode 100644
@@ -992,11 +992,11 @@ index 0000000000..beb1957d46
 +-- 
 +2.25.1
 +
-diff --git a/package/erlang/25.0.4/0001-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/25.0.4/0001-erts-emulator-reorder-inclued-headers-paths.patch
+diff --git a/package/erlang/25.1/0001-erts-emulator-reorder-inclued-headers-paths.patch b/package/erlang/25.1/0001-erts-emulator-reorder-inclued-headers-paths.patch
 new file mode 100644
 index 0000000000..069d69784e
 --- /dev/null
-+++ b/package/erlang/25.0.4/0001-erts-emulator-reorder-inclued-headers-paths.patch
++++ b/package/erlang/25.1/0001-erts-emulator-reorder-inclued-headers-paths.patch
 @@ -0,0 +1,49 @@
 +From fe9a45130bcf1fc80a15628fbf14bf5619d84c1a Mon Sep 17 00:00:00 2001
 +From: Romain Naour <romain.naour@openwide.fr>
@@ -1047,11 +1047,11 @@ index 0000000000..069d69784e
 +-- 
 +2.25.1
 +
-diff --git a/package/erlang/25.0.4/0002-erlang-enable-deterministic-builds.patch b/package/erlang/25.0.4/0002-erlang-enable-deterministic-builds.patch
+diff --git a/package/erlang/25.1/0002-erlang-enable-deterministic-builds.patch b/package/erlang/25.1/0002-erlang-enable-deterministic-builds.patch
 new file mode 100644
 index 0000000000..6a3345e6d6
 --- /dev/null
-+++ b/package/erlang/25.0.4/0002-erlang-enable-deterministic-builds.patch
++++ b/package/erlang/25.1/0002-erlang-enable-deterministic-builds.patch
 @@ -0,0 +1,28 @@
 +From 6f015234f5a82d50fff05f944b3adc2d226174fc Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1081,11 +1081,11 @@ index 0000000000..6a3345e6d6
 +-- 
 +2.25.1
 +
-diff --git a/package/erlang/25.0.4/0003-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/25.0.4/0003-disksup-update-df-call-to-work-with-Busybox.patch
+diff --git a/package/erlang/25.1/0003-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/25.1/0003-disksup-update-df-call-to-work-with-Busybox.patch
 new file mode 100644
 index 0000000000..97f410b18c
 --- /dev/null
-+++ b/package/erlang/25.0.4/0003-disksup-update-df-call-to-work-with-Busybox.patch
++++ b/package/erlang/25.1/0003-disksup-update-df-call-to-work-with-Busybox.patch
 @@ -0,0 +1,28 @@
 +From 2275a2743b85c8915ff64d487cfe0fd1367424e8 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1164,14 +1164,14 @@ index 15931b5896..1ad7f4868a 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 338545a0ba..9fc5fa3c07 100644
+index 338545a0ba..3f6693ffca 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,5 +1,13 @@
 -# From https://github.com/erlang/otp/releases/download/OTP-22.3.4.22/SHA256.txt
 -sha256  e7f0793e62f8da4f7551dc9c1c0de76c40f19773ba516121fc56315c840f60cc  otp_src_22.3.4.22.tar.gz
-+# From https://github.com/erlang/otp/releases/download/OTP-25.0.4/SHA256.txt
-+sha256  8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf  otp_src_25.0.4.tar.gz
++# From https://github.com/erlang/otp/releases/download/OTP-25.1/SHA256.txt
++sha256  a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31  otp_src_25.1.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-24.3.2/SHA256.txt
 +sha256  fb39eecf5a5710200871c85c11251e27afce7c2a11f569bd6394c6d48240ec8d  otp_src_24.3.2.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-23.3.4.14/SHA256.txt
@@ -1184,7 +1184,7 @@ index 338545a0ba..9fc5fa3c07 100644
  # Hash for license file
  sha256  809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index a76bda4437..b544f2e438 100644
+index a76bda4437..710b26b0e5 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -4,8 +4,31 @@
@@ -1211,8 +1211,8 @@ index a76bda4437..b544f2e438 100644
 +ERLANG_VERSION = 24.3.2
 +ERLANG_ERTS_VSN = 12.3
 +else
-+ERLANG_VERSION = 25.0.4
-+ERLANG_ERTS_VSN = 13.0.4
++ERLANG_VERSION = 25.1
++ERLANG_ERTS_VSN = 13.1
 +endif
 +endif
 +endif
@@ -1246,5 +1246,5 @@ index a76bda4437..b544f2e438 100644
  # The configure checks for these functions fail incorrectly
  ERLANG_CONF_ENV = ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
 -- 
-2.25.1
+2.37.0 (Apple Git-136)
 

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/erlang:25.0.4-ubuntu-jammy-20220428
+FROM hexpm/erlang:25.1-ubuntu-jammy-20220428
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
 description="Container with everything needed to build Nerves Systems"


### PR DESCRIPTION
See https://www.erlang.org/patches/otp-25.1

There was a vulnerability referenced in ssl and it was suggested that updating to 25.1 is best.