### PR TITLE
Fix checking bash source in nerves-env.sh

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -38,7 +38,7 @@ fi
 # Detect if this script has been run directly rather than sourced, since
 # that won't work.
 if [[ "$SHELL" = "/bin/bash" ]]; then
-    if [[ "$1" != "bash" && "$1" != "-bash" && "$1" != "/bin/bash" ]]; then
+    if [[ "$0" != "bash" && "$0" != "-bash" && "$0" != "/bin/bash" ]]; then
         echo ERROR: This scripted should be sourced from bash:
         echo
         echo source "${BASH_SOURCE[@]}"


### PR DESCRIPTION
This was mistakenly changed when enabling shellchecks. Apparently the arg will only be in $0 when sourcing, so using $1 causes failures even when bash was correctly used to source.

Wasn't detected locally because zsh was used and only seen recently from some CI processes were forcefully using bash 🤦 