### PR TITLE
Don't fail build for strip errors

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -174,6 +174,8 @@ for EXECUTABLE in $EXECUTABLES; do
 
         # Strip debug information from ELF binaries
         # Symbols are still available to the user in the release directory.
-        $STRIP "$EXECUTABLE"
+        if ! $STRIP "$EXECUTABLE"; then
+            echo "WARNING: Can't remove debug symbols from $EXECUTABLE. This is expected for precompiled Rust."
+        fi
     fi
 done


### PR DESCRIPTION
Since executables are already checked for compatibility with the target
processor, it's unnecessary to fail for strip errors. If strip fails,
just move on and print out a warning. This fixes issues with precompiled
Rust binaries that shows up as the following error:

```
not enough room for program headers, try linking with -N
```

Since the Rust binaries are precompiled, you can't relink, but it's
unnecessary anyway since the binaries work fine.
