### PR TITLE
Don't consume stderr in `merge-squashfs`

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -184,7 +184,7 @@ find_to_pseudofile "$overlay_dir" >>pseudofile.in
 # remove repeated entries to avoid warnings from mksquashfs
 awk '!x[$1]++' pseudofile.in > pseudofile
 
-unsquashfs "$input_squashfs" >/dev/null 2>/dev/null
+unsquashfs "$input_squashfs" >/dev/null
 cp -Rf "$overlay_dir/." "$workdir/squashfs-root"
 mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -sort "$squashfs_priorities" -noappend -no-recovery -no-progress $NERVES_MKSQUASHFS_FLAGS
 


### PR DESCRIPTION
Part of https://github.com/nerves-project/nerves/issues/877 for adding more useful output during the firmware build process.

https://github.com/nerves-project/nerves/issues/876 shows cases where `mix firmware` fails to build. In reproducing, I found that `merge-squashfs` was failing silently. Specifically at this line because `2>/dev/null` was forwarding stderr to be ignored.

Instead, this changes to let stderr through so more helpful messages can be reviewed