### PR TITLE
Don't prompt on non-interactive terminals

### DIFF
--- a/create-build.sh
+++ b/create-build.sh
@@ -137,8 +137,15 @@ elif ! diff "$NERVES_BR_STATE_FILE" "$NERVES_BR_EXPECTED_STATE_FILE" >/dev/null;
     echo "It is highly recommended to rebuild clean."
     echo "To do this, go to $BUILD_DIR, and run 'make clean'."
     echo
-    echo "Press return to acknowledge or CTRL-C to stop"
-    read -r
+
+    if [ -t 0 ]; then
+        echo "Press return to acknowledge or CTRL-C to stop"
+        read -r
+    else
+	echo "WARNING: Detected non-interactive terminal. Blindly continuing..."
+	sleep 5
+    fi
+
     create_buildroot_dir
 fi
 


### PR DESCRIPTION
When nerves_system_br or its patches change, there's a warning that you
may need to build clean. It requires an acknowledgment. When building
with a non-interactive terminal, like when being called from Elixir,
it's not possible to acknowledge it. This detects the case and prints a
warning about blindly continuing since that's often the right answer for
expert users anyway. There's a pause, though, so it's easier to see in
the flood of Buildroot compilation messages.
