### PR TITLE
buildroot: add host-pylibfdt updates for new U-Boot

### DIFF
--- a/patches/buildroot/0015-package-python-pylibfdt-add-host-python-package.patch
+++ b/patches/buildroot/0015-package-python-pylibfdt-add-host-python-package.patch
@@ -1,0 +1,26 @@
+From 4d2b2fd95c038f28debf05b57e0605dae6b13b61 Mon Sep 17 00:00:00 2001
+From: Christian Stewart <christian@aperture.us>
+Date: Wed, 26 Jul 2023 13:28:37 -0700
+Subject: [PATCH] package/python-pylibfdt: add host python package
+
+Signed-off-by: Christian Stewart <christian@aperture.us>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ package/python-pylibfdt/python-pylibfdt.mk | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/package/python-pylibfdt/python-pylibfdt.mk b/package/python-pylibfdt/python-pylibfdt.mk
+index dc68de83b3..077c60c093 100644
+--- a/package/python-pylibfdt/python-pylibfdt.mk
++++ b/package/python-pylibfdt/python-pylibfdt.mk
+@@ -11,5 +11,7 @@ PYTHON_PYLIBFDT_SETUP_TYPE = setuptools
+ PYTHON_PYLIBFDT_LICENSE = BSD-2-Clause or GPL-2.0+
+ PYTHON_PYLIBFDT_LICENSE_FILES = BSD-2-Clause GPL
+ PYTHON_PYLIBFDT_DEPENDENCIES = host-python-setuptools-scm host-swig
++HOST_PYTHON_PYLIBFDT_DEPENDENCIES = host-python-setuptools-scm host-swig
+ 
+ $(eval $(python-package))
++$(eval $(host-python-package))
+-- 
+2.34.1
+

--- a/patches/buildroot/0016-boot-uboot-add-host-python-pylibfdt-dependency-if-ne.patch
+++ b/patches/buildroot/0016-boot-uboot-add-host-python-pylibfdt-dependency-if-ne.patch
@@ -1,0 +1,50 @@
+From 417aa3d4f53d1b62cabbd29c17b330cc96336a0e Mon Sep 17 00:00:00 2001
+From: Christian Stewart <christian@aperture.us>
+Date: Wed, 26 Jul 2023 13:28:38 -0700
+Subject: [PATCH] boot/uboot: add host-python-pylibfdt dependency if needed
+
+Until now, BR2_TARGET_UBOOT_NEEDS_PYLIBFDT was only bringing host-swig
+as a dependency, because U-Boot was building its own pylibfdt, which
+requires host-swig.
+
+However, since commit
+231d79c81e9a1f8c2ef14861374a40fcdc5e6b33 ("boot/uboot: set DTC path
+when BR2_TARGET_UBOOT_NEEDS_DTC"), in which we tell U-Boot to use the
+Buildroot built DTC, a consequence is that U-Boot no longer builds its
+own pylibfdt: it expects the system to provided it. So now,
+BR2_TARGET_UBOOT_NEEDS_PYLIBFDT really needs to bring
+host-python-pylibfdt. The dependency on host-swig is no longer needed,
+as what we need is host-python-pylibfdt, and it is an internal detail
+of pylibfdt that it needs host-swig to build.
+
+Fixes:
+
+  https://gitlab.com/buildroot.org/buildroot/-/jobs/4749556137
+  https://gitlab.com/buildroot.org/buildroot/-/jobs/4749556224
+  https://gitlab.com/buildroot.org/buildroot/-/jobs/4749556227
+  https://gitlab.com/buildroot.org/buildroot/-/jobs/4749556229
+  https://gitlab.com/buildroot.org/buildroot/-/jobs/4749556230
+
+Signed-off-by: Christian Stewart <christian@aperture.us>
+Tested-by: Giulio Benetti <giulio.benetti@benettiengineering.com>
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ boot/uboot/uboot.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/boot/uboot/uboot.mk b/boot/uboot/uboot.mk
+index 01d62622f3..bd40eeb251 100644
+--- a/boot/uboot/uboot.mk
++++ b/boot/uboot/uboot.mk
+@@ -217,7 +217,7 @@ UBOOT_DEPENDENCIES += host-python3 host-python-setuptools
+ endif
+ 
+ ifeq ($(BR2_TARGET_UBOOT_NEEDS_PYLIBFDT),y)
+-UBOOT_DEPENDENCIES += host-swig
++UBOOT_DEPENDENCIES += host-python-pylibfdt
+ endif
+ 
+ ifeq ($(BR2_TARGET_UBOOT_NEEDS_PYELFTOOLS),y)
+-- 
+2.34.1
+


### PR DESCRIPTION
This fixes a U-Boot build error on MangoPi and an Allwinner A64
configurations.
