### PR TITLE
pppd: bump to 2.5.0 to fix GCC 13 compiler error

### DIFF
--- a/patches/buildroot/0015-package-pppd-bump-version-to-2.5.0.patch
+++ b/patches/buildroot/0015-package-pppd-bump-version-to-2.5.0.patch
@@ -1,0 +1,567 @@
+From ccf2e5557dd8cc542bef4f84a2e9538fd0afa86b Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd@kuhls.net>
+Date: Sun, 24 Sep 2023 20:34:08 +0200
+Subject: [PATCH] package/pppd: bump version to 2.5.0
+
+Removed all patches, they are now included in this release.
+Added other patches fixing errors.
+
+Removed option BR2_PACKAGE_PPPD_RADIUS, upstream build system, now auto-
+conf-based, does not support disabling the radius plugin.
+
+Removed BR2_PACKAGE_PPPD_OVERWRITE_RESOLV_CONF, upstream now defaults to
+/etc, quoting README:
+"Note that if you have built and installed previous versions of this
+package and you want to continue having configuration and TDB files in
+/etc/ppp, you will need to use the --sysconfdir option to ./configure."
+
+Switched build system to autoconf, added optional systemd support.
+
+Added configure option to enable multilink support which now defaults to
+false but was enabled before:
+https://github.com/ppp-project/ppp/blob/2.4.9/pppd/Makefile.linux#L57
+
+Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+---
+ ...eck-to-see-if-we-have-struct-sockadd.patch |  44 ++++++
+ ...n-with-older-glibc-or-kernel-headers.patch |  60 ---------
+ ...xing-up-parsing-in-radiusclient.conf.patch |  56 ++++++++
+ ...pd-eap-tls.c-fix-build-with-libressl.patch |  36 -----
+ ...stray-include-of-an-openssl-header-w.patch |  31 +++++
+ ....c-use-uint32_t-instead-of-u_int32_t.patch |  64 +++++++++
+ package/pppd/Config.in                        |  17 ---
+ package/pppd/pppd.hash                        |   9 +-
+ package/pppd/pppd.mk                          | 127 ++++--------------
+ 9 files changed, 225 insertions(+), 219 deletions(-)
+ create mode 100644 package/pppd/0001-Add-configure-check-to-see-if-we-have-struct-sockadd.patch
+ delete mode 100644 package/pppd/0001-pppd-Fix-compilation-with-older-glibc-or-kernel-headers.patch
+ create mode 100644 package/pppd/0002-Closes-411-Fixing-up-parsing-in-radiusclient.conf.patch
+ delete mode 100644 package/pppd/0002-pppd-eap-tls.c-fix-build-with-libressl.patch
+ create mode 100644 package/pppd/0003-Fixes-issue-429-stray-include-of-an-openssl-header-w.patch
+ create mode 100644 package/pppd/0004-pppd-ppp-sha1.c-use-uint32_t-instead-of-u_int32_t.patch
+
+diff --git a/package/pppd/0001-Add-configure-check-to-see-if-we-have-struct-sockadd.patch b/package/pppd/0001-Add-configure-check-to-see-if-we-have-struct-sockadd.patch
+new file mode 100644
+index 0000000000..9e41110400
+--- /dev/null
++++ b/package/pppd/0001-Add-configure-check-to-see-if-we-have-struct-sockadd.patch
+@@ -0,0 +1,44 @@
++From 9d6d326b2530cffb1414e4c401675117c42d43ce Mon Sep 17 00:00:00 2001
++From: Eivind Naess <eivnaes@yahoo.com>
++Date: Sun, 23 Apr 2023 11:30:43 -0700
++Subject: [PATCH] Add configure check to see if we have struct sockaddr_ll
++
++Fixes issue #411.
++
++Signed-off-by: Eivind Naess <eivnaes@yahoo.com>
++
++Upstream: https://github.com/ppp-project/ppp/commit/9d6d326b2530cffb1414e4c401675117c42d43ce
++
++Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
++---
++ configure.ac                   | 3 ++-
++ pppd/plugins/pppoe/config.h.in | 2 ++
++ 2 files changed, 4 insertions(+), 1 deletion(-)
++
++diff --git a/configure.ac b/configure.ac
++index 1180f64..38b24af 100644
++--- a/configure.ac
+++++ b/configure.ac
++@@ -75,7 +75,8 @@ AM_COND_IF([LINUX], [
++         linux/if_ether.h        \
++         linux/if_packet.h       \
++         netinet/if_ether.h      \
++-        netpacket/packet.h])])
+++        netpacket/packet.h])
+++    AC_CHECK_TYPES([struct sockaddr_ll], [], [], [#include <linux/if_packet.h>])])
++ 
++ AC_CHECK_SIZEOF(unsigned int)
++ AC_CHECK_SIZEOF(unsigned long)
++diff --git a/pppd/plugins/pppoe/config.h.in b/pppd/plugins/pppoe/config.h.in
++index d447f5e..d7d61c0 100644
++--- a/pppd/plugins/pppoe/config.h.in
+++++ b/pppd/plugins/pppoe/config.h.in
++@@ -69,3 +69,5 @@
++ /* The size of `unsigned short', as computed by sizeof. */
++ #undef SIZEOF_UNSIGNED_SHORT
++ 
+++/* Define to 1 if the system has the type `struct sockaddr_ll'. */
+++#undef HAVE_STRUCT_SOCKADDR_LL
++-- 
++2.39.2
++
+diff --git a/package/pppd/0001-pppd-Fix-compilation-with-older-glibc-or-kernel-headers.patch b/package/pppd/0001-pppd-Fix-compilation-with-older-glibc-or-kernel-headers.patch
+deleted file mode 100644
+index 86d8b8f4e3..0000000000
+--- a/package/pppd/0001-pppd-Fix-compilation-with-older-glibc-or-kernel-headers.patch
++++ /dev/null
+@@ -1,60 +0,0 @@
+-From 98ec18f098e5ef68e3a8cc6954fcaf5a7fb8b7be Mon Sep 17 00:00:00 2001
+-From: pali <7141871+pali@users.noreply.github.com>
+-Date: Mon, 15 Feb 2021 07:54:01 +0100
+-Subject: [PATCH] pppd: Fix compilation with older glibc or kernel headers
+- (#248)
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-glibc versions prior to 2.24 do not define SOL_NETLINK and linux kernel
+-versions prior to 4.3 do not define NETLINK_CAP_ACK. So add fallback
+-definitions for these macros into pppd/sys-linux.c file.
+-
+-Also extend description why we call SOL_NETLINK/NETLINK_CAP_ACK option.
+-
+-Signed-off-by: Pali Rohár <pali@kernel.org>
+-
+-[Retrieved from:
+-https://github.com/ppp-project/ppp/commit/98ec18f098e5ef68e3a8cc6954fcaf5a7fb8b7be]
+-Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+----
+- pppd/sys-linux.c | 18 +++++++++++++++++-
+- 1 file changed, 17 insertions(+), 1 deletion(-)
+-
+-diff --git a/pppd/sys-linux.c b/pppd/sys-linux.c
+-index 85033d97..50c4f2da 100644
+---- a/pppd/sys-linux.c
+-+++ b/pppd/sys-linux.c
+-@@ -125,6 +125,14 @@
+- #include <linux/netlink.h>
+- #include <linux/rtnetlink.h>
+- #include <linux/if_addr.h>
+-+/* glibc versions prior to 2.24 do not define SOL_NETLINK */
+-+#ifndef SOL_NETLINK
+-+#define SOL_NETLINK 270
+-+#endif
+-+/* linux kernel versions prior to 4.3 do not define/support NETLINK_CAP_ACK */
+-+#ifndef NETLINK_CAP_ACK
+-+#define NETLINK_CAP_ACK 10
+-+#endif
+- #endif
+- 
+- #include "pppd.h"
+-@@ -2843,7 +2851,15 @@ static int append_peer_ipv6_address(unsigned int iface, struct in6_addr *local_a
+-     if (fd < 0)
+-         return 0;
+- 
+--    /* do not ask for error message content */
+-+    /*
+-+     * Tell kernel to not send to us payload of acknowledgment error message.
+-+     * NETLINK_CAP_ACK option is supported since Linux kernel version 4.3 and
+-+     * older kernel versions always send full payload in acknowledgment netlink
+-+     * message. We ignore payload of this message as we need only error code,
+-+     * to check if our set remote peer address request succeeded or failed.
+-+     * So ignore return value from the following setsockopt() call as setting
+-+     * option NETLINK_CAP_ACK means for us just a kernel hint / optimization.
+-+     */
+-     one = 1;
+-     setsockopt(fd, SOL_NETLINK, NETLINK_CAP_ACK, &one, sizeof(one));
+- 
+diff --git a/package/pppd/0002-Closes-411-Fixing-up-parsing-in-radiusclient.conf.patch b/package/pppd/0002-Closes-411-Fixing-up-parsing-in-radiusclient.conf.patch
+new file mode 100644
+index 0000000000..5fa3ded756
+--- /dev/null
++++ b/package/pppd/0002-Closes-411-Fixing-up-parsing-in-radiusclient.conf.patch
+@@ -0,0 +1,56 @@
++From 7f89208b860ea0c41636410bfdb6a609b2772f47 Mon Sep 17 00:00:00 2001
++From: Eivind Naess <eivnaes@yahoo.com>
++Date: Sun, 23 Apr 2023 11:37:01 -0700
++Subject: [PATCH] Closes #411, Fixing up parsing in radiusclient.conf
++
++Adding curly braces to fix the code.
++
++Signed-off-by: Eivind Naess <eivnaes@yahoo.com>
++
++Upstream: https://github.com/ppp-project/ppp/commit/7f89208b860ea0c41636410bfdb6a609b2772f47
++
++Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
++---
++ pppd/plugins/radius/config.c | 12 ++++++++----
++ 1 file changed, 8 insertions(+), 4 deletions(-)
++
++diff --git a/pppd/plugins/radius/config.c b/pppd/plugins/radius/config.c
++index 39744fc..e1a4814 100644
++--- a/pppd/plugins/radius/config.c
+++++ b/pppd/plugins/radius/config.c
++@@ -235,24 +235,28 @@ int rc_read_config(char *filename)
++ 
++ 		switch (option->type) {
++ 			case OT_STR:
++-				 if (set_option_str(filename, line, option, p) < 0)
+++				if (set_option_str(filename, line, option, p) < 0) {
++ 					fclose(configfd);
++ 					return (-1);
+++				}
++ 				break;
++ 			case OT_INT:
++-				 if (set_option_int(filename, line, option, p) < 0)
+++				if (set_option_int(filename, line, option, p) < 0) {
++ 					fclose(configfd);
++ 					return (-1);
+++				}
++ 				break;
++ 			case OT_SRV:
++-				 if (set_option_srv(filename, line, option, p) < 0)
+++				if (set_option_srv(filename, line, option, p) < 0) {
++ 					fclose(configfd);
++ 					return (-1);
+++				}
++ 				break;
++ 			case OT_AUO:
++-				 if (set_option_auo(filename, line, option, p) < 0)
+++				if (set_option_auo(filename, line, option, p) < 0) {
++ 					fclose(configfd);
++ 					return (-1);
+++				}
++ 				break;
++ 			default:
++ 				fatal("rc_read_config: impossible case branch!");
++-- 
++2.39.2
++
+diff --git a/package/pppd/0002-pppd-eap-tls.c-fix-build-with-libressl.patch b/package/pppd/0002-pppd-eap-tls.c-fix-build-with-libressl.patch
+deleted file mode 100644
+index aefdc5b7a4..0000000000
+--- a/package/pppd/0002-pppd-eap-tls.c-fix-build-with-libressl.patch
++++ /dev/null
+@@ -1,36 +0,0 @@
+-From b0a011bc4abac8cb3de8dfff42b754ed236ecf0f Mon Sep 17 00:00:00 2001
+-From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+-Date: Mon, 4 Jul 2022 10:07:03 +0200
+-Subject: [PATCH] pppd/eap-tls.c: fix build with libressl (#338)
+-
+-Fix the following build failure with libressl:
+-
+-eap-tls.c: In function 'ssl_msg_callback':
+-eap-tls.c:1284:10: error: 'SSL3_RT_HEADER' undeclared (first use in this function); did you mean 'SSL3_RT_ALERT'?
+- 1284 |     case SSL3_RT_HEADER:
+-      |          ^~~~~~~~~~~~~~
+-      |          SSL3_RT_ALERT
+-
+-Fixes:
+- - http://autobuild.buildroot.org/results/7d721833bddf73531fa03b0a626511af6826d0df
+-
+-Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+-[Retrieved (and backported) from:
+-https://github.com/ppp-project/ppp/commit/b0a011bc4abac8cb3de8dfff42b754ed236ecf0f]
+----
+- pppd/eap-tls.c | 2 +-
+- 1 file changed, 1 insertion(+), 1 deletion(-)
+-
+-diff --git a/pppd/eap-tls.c b/pppd/eap-tls.c
+-index b9bab842..40796d58 100644
+---- a/pppd/eap-tls.c
+-+++ b/pppd/eap-tls.c
+-@@ -61,7 +61,7 @@
+- #include "mppe.h"
+- #include "pathnames.h"
+- 
+--#if OPENSSL_VERSION_NUMBER < 0x10100000L
+-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+- 
+- #define TLS_method SSLv23_method
+- 
+diff --git a/package/pppd/0003-Fixes-issue-429-stray-include-of-an-openssl-header-w.patch b/package/pppd/0003-Fixes-issue-429-stray-include-of-an-openssl-header-w.patch
+new file mode 100644
+index 0000000000..b5f9f319f9
+--- /dev/null
++++ b/package/pppd/0003-Fixes-issue-429-stray-include-of-an-openssl-header-w.patch
+@@ -0,0 +1,31 @@
++From cf7ac82a610bbfee57512cba345f7d49c02563a2 Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Eivind=20N=C3=A6ss?= <eivnaes@yahoo.com>
++Date: Wed, 14 Jun 2023 23:19:46 +0000
++Subject: [PATCH] Fixes issue #429, stray include of an openssl header was
++ removed
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Signed-off-by: Eivind Næss <eivnaes@yahoo.com>
++
++Upstream: https://github.com/ppp-project/ppp/pull/431
++
++Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
++---
++ pppd/crypto_ms.c | 2 --
++ 1 file changed, 2 deletions(-)
++
++diff --git a/pppd/crypto_ms.c b/pppd/crypto_ms.c
++index a9ddd5fda..ccf8129d4 100644
++--- a/pppd/crypto_ms.c
+++++ b/pppd/crypto_ms.c
++@@ -122,8 +122,6 @@ MakeKey(const unsigned char *key, unsigned char *des_key)
++ 	DES_set_odd_parity((DES_cblock *)des_key);
++ }
++ 
++-#include <openssl/evp.h>
++-
++ int
++ DesEncrypt(const unsigned char *clear, const unsigned char *key, unsigned char *cipher)
++ {
+diff --git a/package/pppd/0004-pppd-ppp-sha1.c-use-uint32_t-instead-of-u_int32_t.patch b/package/pppd/0004-pppd-ppp-sha1.c-use-uint32_t-instead-of-u_int32_t.patch
+new file mode 100644
+index 0000000000..bce7687b9e
+--- /dev/null
++++ b/package/pppd/0004-pppd-ppp-sha1.c-use-uint32_t-instead-of-u_int32_t.patch
+@@ -0,0 +1,64 @@
++From 7eb0cc63e38a1fcaff24bc3ca146c13414a1420e Mon Sep 17 00:00:00 2001
++From: Bernd Kuhls <bernd@kuhls.net>
++Date: Sun, 18 Jun 2023 15:53:43 +0200
++Subject: [PATCH] pppd/ppp-sha1.c: use uint32_t instead of u_int32_t
++
++Fixes build with musl-libc toolchains.
++
++Upstream: https://github.com/ppp-project/ppp/pull/432
++
++Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
++---
++ pppd/ppp-sha1.c | 14 +++++++-------
++ 1 file changed, 7 insertions(+), 7 deletions(-)
++
++diff --git a/pppd/ppp-sha1.c b/pppd/ppp-sha1.c
++index ab4dcd5..9ff3a24 100644
++--- a/pppd/ppp-sha1.c
+++++ b/pppd/ppp-sha1.c
++@@ -110,14 +110,14 @@ static void sha1_clean(PPP_MD_CTX *ctx)
++ #include <netinet/in.h>	/* htonl() */
++ 
++ typedef struct {
++-    u_int32_t state[5];
++-    u_int32_t count[2];
+++    uint32_t state[5];
+++    uint32_t count[2];
++     unsigned char buffer[64];
++ } SHA1_CTX;
++ 
++ 
++ static void
++-SHA1_Transform(u_int32_t[5], const unsigned char[64]);
+++SHA1_Transform(uint32_t[5], const unsigned char[64]);
++ 
++ #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
++ 
++@@ -138,12 +138,12 @@ SHA1_Transform(u_int32_t[5], const unsigned char[64]);
++ /* Hash a single 512-bit block. This is the core of the algorithm. */
++ 
++ static void
++-SHA1_Transform(u_int32_t state[5], const unsigned char buffer[64])
+++SHA1_Transform(uint32_t state[5], const unsigned char buffer[64])
++ {
++-    u_int32_t a, b, c, d, e;
+++    uint32_t a, b, c, d, e;
++     typedef union {
++ 	unsigned char c[64];
++-	u_int32_t l[16];
+++	uint32_t l[16];
++     } CHAR64LONG16;
++     CHAR64LONG16 *block;
++ 
++@@ -236,7 +236,7 @@ SHA1_Update(SHA1_CTX *context, const unsigned char *data, unsigned int len)
++ static void
++ SHA1_Final(unsigned char digest[20], SHA1_CTX *context)
++ {
++-    u_int32_t i, j;
+++    uint32_t i, j;
++     unsigned char finalcount[8];
++ 
++     for (i = 0; i < 8; i++) {
++-- 
++2.39.2
++
+diff --git a/package/pppd/Config.in b/package/pppd/Config.in
+index 898d95f0ee..88c2180a9b 100644
+--- a/package/pppd/Config.in
++++ b/package/pppd/Config.in
+@@ -19,23 +19,6 @@ config BR2_PACKAGE_PPPD_FILTER
+ 	  the pppd active-filter and pass-filter options
+ 	  are available.
+ 
+-config BR2_PACKAGE_PPPD_RADIUS
+-	bool "radius"
+-	help
+-	  Install RADIUS support for pppd
+-
+-config BR2_PACKAGE_PPPD_OVERWRITE_RESOLV_CONF
+-	bool "overwrite /etc/resolv.conf"
+-	default y
+-	help
+-	  Overwrite /etc/resolv.conf instead of maintaining the
+-	  separate list of nameservers in /etc/ppp/resolv.conf
+-
+-	  Note that the pppd default of writing to /etc/ppp/resolv.conf
+-	  does not work on a read-only rootfs unless you make it
+-	  writable in your rootfs customizations (e.g. by linking it to
+-	  a file in tmpfs or by mounting a writable filesystem on it).
+-
+ endif
+ 
+ comment "pppd needs a toolchain w/ dynamic library"
+diff --git a/package/pppd/pppd.hash b/package/pppd/pppd.hash
+index 3d471695bb..9a293e7d8d 100644
+--- a/package/pppd/pppd.hash
++++ b/package/pppd/pppd.hash
+@@ -1,7 +1,4 @@
+ # Locally calculated
+-sha256  675bff4f366174649f4a3c92fd32ac476e694164ff2b0b7710019b6ead9c561e  pppd-2.4.9.tar.gz
+-sha256  3990c65c506885f7bb75455d1d6188743a14ad46f5b62e136ef3739aed52c532  pppd/tdb.c
+-sha256  1822ead9d2854adfbd282322b29730a3fec4cc67f6f6a2e487aad3476e3afd59  pppd/plugins/pppoatm/COPYING
+-sha256  d759ec16875a69c2d5529f8cb3c040fef8fe38d26f70457aadb73c91b72746c8  pppdump/bsd-comp.c
+-sha256  c0d0f14b6ec9948332f10ded741293ed1f3b96e0d266e4903b605a6e1f8af7cd  pppd/ccp.c
+-sha256  367f334c509db2b293aea5ce9f54284d9a9f6e0a9e0c6e305d544079baf8ab63  pppd/plugins/passprompt.c
++sha256  425a5b2df592f4b79e251e5b0d3af48265904162cb0906691a5d35ec355b426d  pppd-2.5.0.tar.gz
++sha256  5d588eb3b157d52112afea935c88a7ff9efddc1e2d95a42c25d3b96ad9055008  LICENSE.BSD
++sha256  8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643  LICENSE.GPL-2
+diff --git a/package/pppd/pppd.mk b/package/pppd/pppd.mk
+index 25d017a84f..616b843e3d 100644
+--- a/package/pppd/pppd.mk
++++ b/package/pppd/pppd.mk
+@@ -4,119 +4,46 @@
+ #
+ ################################################################################
+ 
+-PPPD_VERSION = 2.4.9
+-PPPD_SITE = $(call github,paulusmack,ppp,ppp-$(PPPD_VERSION))
++# The tarball provided at https://download.samba.org/pub/ppp/ does not
++# include the license files yet so we use the github tarball.
++PPPD_VERSION = 2.5.0
++PPPD_SITE = $(call github,ppp-project,ppp,ppp-$(PPPD_VERSION))
+ PPPD_LICENSE = LGPL-2.0+, LGPL, BSD-4-Clause, BSD-3-Clause, GPL-2.0+
+-PPPD_LICENSE_FILES = \
+-	pppd/tdb.c pppd/plugins/pppoatm/COPYING \
+-	pppdump/bsd-comp.c pppd/ccp.c pppd/plugins/passprompt.c
++PPPD_LICENSE_FILES = LICENSE.BSD LICENSE.GPL-2
+ PPPD_CPE_ID_VENDOR = point-to-point_protocol_project
+ PPPD_CPE_ID_PRODUCT = point-to-point_protocol
+ PPPD_SELINUX_MODULES = ppp
+-
+-PPPD_MAKE_OPTS = HAVE_INET6=y
++PPPD_AUTORECONF = YES
++PPPD_INSTALL_STAGING = YES
++PPPD_CONF_OPTS = --enable-multilink
+ 
+ ifeq ($(BR2_PACKAGE_OPENSSL),y)
++PPPD_CONF_OPTS += \
++	--enable-eaptls \
++	--enable-openssl-engine \
++	--enable-peap \
++	--with-openssl=$(STAGING_DIR)/usr
+ PPPD_DEPENDENCIES += openssl
+-PPPD_MAKE_OPTS += USE_EAPTLS=y
+ else
+-PPPD_MAKE_OPTS += \
+-	USE_CRYPT=y \
+-	USE_EAPTLS=
++PPPD_CONF_OPTS += \
++	--disable-eaptls \
++	--disable-openssl-engine \
++	--disable-peap \
++	--without-openssl
+ endif
+ 
+-PPPD_INSTALL_STAGING = YES
+-PPPD_TARGET_BINS = chat pppd pppdump pppstats
+-PPPD_RADIUS_CONF = \
+-	dictionary dictionary.ascend dictionary.compat \
+-	dictionary.merit dictionary.microsoft \
+-	issue port-id-map realms servers radiusclient.conf
+-
+ ifeq ($(BR2_PACKAGE_PPPD_FILTER),y)
++PPPD_CONF_OPTS += --with-pcap=$(STAGING_DIR)/usr
+ PPPD_DEPENDENCIES += libpcap
+-PPPD_MAKE_OPTS += FILTER=y
+-endif
+-
+-# pppd defaults to /etc/ppp/resolv.conf, which not be writable and is
+-# definitely not useful since the C library only uses
+-# /etc/resolv.conf. Therefore, we change pppd to use /etc/resolv.conf
+-# instead.
+-define PPPD_SET_RESOLV_CONF
+-	$(SED) 's,ppp/resolv.conf,resolv.conf,' $(@D)/pppd/pathnames.h
+-endef
+-ifeq ($(BR2_PACKAGE_PPPD_OVERWRITE_RESOLV_CONF),y)
+-PPPD_POST_EXTRACT_HOOKS += PPPD_SET_RESOLV_CONF
+-endif
+-
+-ifeq ($(BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_15),y)
+-define PPPD_DROP_IPX
+-	$(SED) 's/-DIPX_CHANGE//' $(PPPD_DIR)/pppd/Makefile.linux
+-endef
+-PPPD_POST_EXTRACT_HOOKS += PPPD_DROP_IPX
++else
++PPPD_CONF_OPTS += --without-pcap
+ endif
+ 
+-define PPPD_CONFIGURE_CMDS
+-	$(SED) 's/FILTER=y/#FILTER=y/' $(PPPD_DIR)/pppd/Makefile.linux
+-	$(SED) 's/ifneq ($$(wildcard \/usr\/include\/pcap-bpf.h),)/ifdef FILTER/' $(PPPD_DIR)/*/Makefile.linux
+-	( cd $(@D); $(TARGET_MAKE_ENV) ./configure --prefix=/usr )
+-endef
+-
+-define PPPD_BUILD_CMDS
+-	$(TARGET_MAKE_ENV) $(MAKE) CC="$(TARGET_CC)" COPTS="$(TARGET_CFLAGS)" \
+-		-C $(@D) $(PPPD_MAKE_OPTS)
+-endef
+-
+-ifeq ($(BR2_PACKAGE_PPPD_RADIUS),y)
+-define PPPD_INSTALL_RADIUS
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/radius/radattr.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/radattr.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/radius/radius.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/radius.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/radius/radrealms.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/radrealms.so
+-	for m in $(PPPD_RADIUS_CONF); do \
+-		$(INSTALL) -m 644 -D $(PPPD_DIR)/pppd/plugins/radius/etc/$$m \
+-			$(TARGET_DIR)/etc/ppp/radius/$$m; \
+-	done
+-	$(SED) 's:/usr/local/etc:/etc:' \
+-		$(TARGET_DIR)/etc/ppp/radius/radiusclient.conf
+-	$(SED) 's:/usr/local/sbin:/usr/sbin:' \
+-		$(TARGET_DIR)/etc/ppp/radius/radiusclient.conf
+-	$(SED) 's:/etc/radiusclient:/etc/ppp/radius:g' \
+-		$(TARGET_DIR)/etc/ppp/radius/*
+-endef
++ifeq ($(BR2_PACKAGE_SYSTEMD),y)
++PPPD_CONF_OPTS += --enable-systemd
++PPPD_DEPENDENCIES += systemd
++else
++PPPD_CONF_OPTS += --disable-systemd
+ endif
+ 
+-define PPPD_INSTALL_TARGET_CMDS
+-	for sbin in $(PPPD_TARGET_BINS); do \
+-		$(INSTALL) -D $(PPPD_DIR)/$$sbin/$$sbin \
+-			$(TARGET_DIR)/usr/sbin/$$sbin; \
+-	done
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/minconn.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/minconn.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/passprompt.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/passprompt.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/passwordfd.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/passwordfd.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/pppoatm/pppoatm.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/pppoatm.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/pppoe/pppoe.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/pppoe.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/pppoe/pppoe-discovery \
+-		$(TARGET_DIR)/usr/sbin/pppoe-discovery
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/winbind.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/winbind.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/pppol2tp/openl2tp.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/openl2tp.so
+-	$(INSTALL) -D $(PPPD_DIR)/pppd/plugins/pppol2tp/pppol2tp.so \
+-		$(TARGET_DIR)/usr/lib/pppd/$(PPPD_VERSION)/pppol2tp.so
+-	$(INSTALL) -D -m 0755 $(PPPD_DIR)/scripts/pon $(TARGET_DIR)/usr/bin/pon
+-	$(INSTALL) -D -m 0755 $(PPPD_DIR)/scripts/poff $(TARGET_DIR)/usr/bin/poff
+-	$(PPPD_INSTALL_RADIUS)
+-endef
+-
+-define PPPD_INSTALL_STAGING_CMDS
+-	$(TARGET_MAKE_ENV) $(MAKE) INSTROOT=$(STAGING_DIR)/ -C $(@D) $(PPPD_MAKE_OPTS) install-devel
+-endef
+-
+-$(eval $(generic-package))
++$(eval $(autotools-package))
+-- 
+2.34.1
+


### PR DESCRIPTION
This pulls in the upstream Buildroot patch for 2.5.0 that hasn't made it
to an official Buildroot release yet.
