### PR TITLE
rpi-distro-firmware-nonfree: bump to 1:20230210-5+rpt2

### DIFF
--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  ff010a5c657cfb5719bac68347cf2a448fa204c9d563245ffd0d48e9ae980bcf  rpi-distro-firmware-nonfree-4db8c5d80daf2220d7824cfa6052f0bb108612ea.tar.gz
+sha256  bb3d8fed40546e03e29d9e635745433f8083391e62d6ff151c895b892776964a  rpi-distro-firmware-nonfree-88aa085bfa1a4650e1ccd88896f8343c22a24055.tar.gz
 sha256  363fb52cb7a74719cc7eda2cf9ebe2984791b6aed70552900a08e8b3ba18833d  debian/config/brcm80211/copyright

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,12 +4,12 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 4db8c5d80daf2220d7824cfa6052f0bb108612ea # 20210315-3+rpt5 + RPI Zero 2W update
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 88aa085bfa1a4650e1ccd88896f8343c22a24055 # 1:20230210-5+rpt2
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/config/brcm80211/copyright
 
 # Notes
-# 1. The brcmfmac43436f-sdio symlinks come from the firmware-brcm80211.postinst script
+# 1. The cyfmac43455-sdio.bin symlink comes from the firmware-brcm80211.postinst script
 # 2. The cyfmac43455-sdio-minimal firmware isn't used. It's for increasing the number
 #    of supported clients in AP mode by removing functionality.
 define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
@@ -18,8 +18,7 @@ define RPI_DISTRO_FIRMWARE_NONFREE_INSTALL_TARGET_CMDS
 	cp -dpfr "$(@D)/debian/config/brcm80211/cypress" "$(TARGET_DIR)/lib/firmware"
 	rm -f "$(TARGET_DIR)/lib/firmware/cypress/cyfmac43455-sdio-minimal.bin"
 	rm -f "$(TARGET_DIR)/lib/firmware/cypress/README.txt"
-	ln -sf brcmfmac43436f-sdio.bin "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.bin"
-	ln -sf brcmfmac43436f-sdio.txt "$(TARGET_DIR)/lib/firmware/brcm/brcmfmac43436-sdio.txt"
+	ln -sf cyfmac43455-sdio-standard.bin "$(TARGET_DIR)/lib/firmware/cypress/cyfmac43455-sdio.bin"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This add RPi 5-specific links to support the BCM43455 WiFi module.

It also contains about 2 years worth of changes since the previous
version. The changelog is at
https://github.com/RPi-Distro/firmware-nonfree/blob/88aa085bfa1a4650e1ccd88896f8343c22a24055/debian/changelog.
