### PR TITLE
Support 'find' for MacOS Sonoma

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -114,12 +114,9 @@ if [ -n "$NOSCRUBS" ]; then
     # exclusions on MacOS and so if you are attempting to skip scrubbing files,
     # the task will fail. To get the proper variable expanded, we need to
     # eval the call.
-    if [[ $(uname -s) == "Darwin" ]]; then
-        # shellcheck disable=SC2294
-        EXECUTABLES=$(eval find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
-    else
-        EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
-    fi
+    # With MacOS Sonoma `find` performs the same as on linux so we attempt that first
+    # and then fallback to `eval` method.
+    EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}" || eval find "$RELEASE_DIR" -type f -perm -100 "${EXCLUSIONS[@]}")
 else
     EXECUTABLES=$(find "$RELEASE_DIR" -type f -perm -100)
 fi


### PR DESCRIPTION
`find` in recent macOS Sonoma -- or possibly due to a Xcode command line tool update -- changed and now matches Linux's.

Instead of leave conditional check from Darwin I am proposing using a simple `||`.

Note: during `mix firmware` if the first `find` fails output to STDERR so a line similar to `find: .../_build/_nerves-tmp/rootfs_overlay/srv/erlang/lib/nautic_net_device-0.1.2/priv/arm/tailscale: unknown primary or operator` will occur.