### PR TITLE
Force mktemp to honor $TMPDIR in merge-squashfs script

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -175,7 +175,8 @@ if [[ ! -d $overlay_dir ]]; then
     exit 1
 fi
 
-workdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'merge-squashfs-tmp')
+# force mktemp to honor $TMPDIR
+workdir=$(mktemp -d -p '' 2>/dev/null || mktemp -d -p '' -t 'merge-squashfs-tmp')
 pushd "$workdir" >/dev/null
 
 unsquash_to_pseudofile "$input_squashfs" >pseudofile.in


### PR DESCRIPTION
This is a proposed solution to https://github.com/nerves-project/nerves/issues/876.

On macOS, `mktemp` will create a temporary directory in `/var/...` which is on a case-insensitive volume. The `merge-squashfs` script will fail when Buildroot packages contain files that differ only in their case.

By adding the `-p ''` argument to `mktemp`, it is forced to honor the `$TMPDIR` environment variable, which the user could specify ahead of time as a special directory on a case-sensitive volume.