### PR TITLE
Add explicit check for $TMPDIR before calling mktemp in merge-squashfs

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -175,8 +175,13 @@ if [[ ! -d $overlay_dir ]]; then
     exit 1
 fi
 
-# force mktemp to honor $TMPDIR
-workdir=$(mktemp -d -p '' 2>/dev/null || mktemp -d -p '' -t 'merge-squashfs-tmp')
+# Use $TMPDIR if it's set
+if [[ -e "$TMPDIR" ]]; then
+    workdir=$(mktemp -d "$TMPDIR/merge-squashfs-tmp.XXXXXXXXXX")
+else
+    workdir=$(mktemp -d)
+fi
+
 pushd "$workdir" >/dev/null
 
 unsquash_to_pseudofile "$input_squashfs" >pseudofile.in


### PR DESCRIPTION
This is a follow-up to #778 and a proposed fix for #781.

Here's what I know:

- `mktemp` on macOS 13 does not support the `-p` option (as reported in #781)
- The `-t` option is problematic
  - The option behaves wildly differently between macOS and Linux
  - Ubuntu 18 manpages claim the `-t` option is deprecated
  - The original fallback invocation of `mktemp -d -t 'merge-squashfs-tmp'` doesn't even work on Linux; the template string requires "X" characters as placeholders
- `mktemp` does not consistently honor `$TMPDIR`
  - Linux `mktemp` honors `$TMPDIR` by default
  - macOS `mktemp` does NOT honor `$TMPDIR` by default

So, my proposed solution avoids `-t` and `-p` and is about as simple and explicit as possible, and it has been tested as working equally well on macOS 13, 14, and Ubuntu 18, and with or without `$TMPDIR` being set.