### PR TITLE
Updated erlang to 26.2.4, added patch for libei naming conflicts

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 26.2.3
+erlang 26.2.4

--- a/patches/buildroot/0007-erlang-support-OTP-21-26.patch
+++ b/patches/buildroot/0007-erlang-support-OTP-21-26.patch
@@ -1,4 +1,4 @@
-From 3282633f5b2d0c405c7f19fd48ddaae83df5b830 Mon Sep 17 00:00:00 2001
+From 9686fe7e968d29eac0abcdf4c8e0a02bbd5f7a5d Mon Sep 17 00:00:00 2001
 From: Frank Hunleth <fhunleth@troodon-software.com>
 Date: Tue, 11 Sep 2018 12:28:41 -0400
 Subject: [PATCH] erlang: support OTP 21 - 26
@@ -50,7 +50,7 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/24.3.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
  create mode 100644 package/erlang/25.3.2/0001-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/25.3.2/0003-disksup-update-df-call-to-work-with-Busybox.patch
- create mode 100644 package/erlang/26.2.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/26.2.4/0001-disksup-update-df-call-to-work-with-Busybox.patch
 
 diff --git a/package/erlang/21.3.8.24/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.3.8.24/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
@@ -951,11 +951,11 @@ index 0000000000..97f410b18c
 +-- 
 +2.25.1
 +
-diff --git a/package/erlang/26.2.3/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/26.2.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
+diff --git a/package/erlang/26.2.4/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/26.2.4/0001-disksup-update-df-call-to-work-with-Busybox.patch
 new file mode 100644
 index 0000000000..9cccce73ac
 --- /dev/null
-+++ b/package/erlang/26.2.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
++++ b/package/erlang/26.2.4/0001-disksup-update-df-call-to-work-with-Busybox.patch
 @@ -0,0 +1,77 @@
 +From 59f0d61699350a6df661c838a502a566b1c02768 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1088,14 +1088,14 @@ index 724f91123b..94cea606d3 100644
  	bool "install megaco application"
  	help
 diff --git a/package/erlang/erlang.hash b/package/erlang/erlang.hash
-index 9fc5a6eabf..b0d8d2df23 100644
+index 9fc5a6eabf..6ecc6341e9 100644
 --- a/package/erlang/erlang.hash
 +++ b/package/erlang/erlang.hash
 @@ -1,5 +1,15 @@
 -# From https://github.com/erlang/otp/releases/download/OTP-26.0.2/SHA256.txt
 -sha256  47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193  otp_src_26.0.2.tar.gz
 +# Calculated manually
-+sha256  2c4e61b24fb1c131d9f30cfe2415320899180debdb71fb59195c72bd9a4ab625  otp_src_26.2.3.tar.gz
++sha256  b51ad69f57e2956dff4c893bcb09ad68fee23a7f8f6bba7d58449516b696de95  otp_src_26.2.4.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-25.3.2/SHA256.txt
 +sha256  aed4e4726cdc587ab820c8379d63e511e46a1b1cc0c59d6a720b51ae625b2510  otp_src_25.3.2.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-24.3.2/SHA256.txt
@@ -1110,7 +1110,7 @@ index 9fc5a6eabf..b0d8d2df23 100644
  # Hash for license file
  sha256  809fa1ed21450f59827d1e9aec720bbc4b687434fa22283c6cb5dd82a47ab9c0  LICENSE.txt
 diff --git a/package/erlang/erlang.mk b/package/erlang/erlang.mk
-index 0889155177..56c29b04bd 100644
+index 0889155177..cf385d2891 100644
 --- a/package/erlang/erlang.mk
 +++ b/package/erlang/erlang.mk
 @@ -4,7 +4,34 @@
@@ -1139,8 +1139,8 @@ index 0889155177..56c29b04bd 100644
 +ERLANG_VERSION = 25.3.2
 +ERLANG_ERTS_VSN = 13.2.2
 +else
-+ERLANG_VERSION = 26.2.3
-+ERLANG_ERTS_VSN = 14.2.3
++ERLANG_VERSION = 26.2.4
++ERLANG_ERTS_VSN = 14.2.4
 +endif
 +endif
 +endif

--- a/patches/buildroot/0015-Fix-for-compilation-errors-due-to-libei-naming-confl.patch
+++ b/patches/buildroot/0015-Fix-for-compilation-errors-due-to-libei-naming-confl.patch
@@ -1,0 +1,51 @@
+From 553561172a43e9a54b25e6dc728660536d1bdd1c Mon Sep 17 00:00:00 2001
+From: Ray Chang <ray@rclabs.org>
+Date: Fri, 19 Apr 2024 00:54:05 +1000
+Subject: [PATCH] Fix for compilation errors due to libei naming conflicts
+
+Signed-off-by: Ray Chang <ray@rclabs.org>
+---
+ .../0002-erlang-libei-arch-compile.patch      | 31 +++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+ create mode 100644 package/erlang/26.2.4/0002-erlang-libei-arch-compile.patch
+
+diff --git a/package/erlang/26.2.4/0002-erlang-libei-arch-compile.patch b/package/erlang/26.2.4/0002-erlang-libei-arch-compile.patch
+new file mode 100644
+index 0000000000..5a3c729289
+--- /dev/null
++++ b/package/erlang/26.2.4/0002-erlang-libei-arch-compile.patch
+@@ -0,0 +1,31 @@
++From 442b23d9dd8d5d66fe70ceef31be7531ac75fa56 Mon Sep 17 00:00:00 2001
++From: Ray Chang <ray@rclabs.org>
++Date: Fri, 19 Apr 2024 00:47:58 +1000
++Subject: [PATCH] Fix for compilation errors due to libei naming conflicts.
++
++Signed-off-by: Ray Chang <ray@rclabs.org>
++---
++ lib/odbc/c_src/Makefile.in | 6 +++---
++ 1 file changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/lib/odbc/c_src/Makefile.in b/lib/odbc/c_src/Makefile.in
++index d1b26743a6..03ed314f6a 100644
++--- a/lib/odbc/c_src/Makefile.in
+++++ b/lib/odbc/c_src/Makefile.in
++@@ -80,10 +80,10 @@ ODBC_INCLUDE = @ODBC_INCLUDE@
++ # ----------------------------------------------------
++ CC =  @CC@
++ CFLAGS = $(TYPEFLAGS) @CFLAGS@ @THR_DEFS@ @DEFS@
++-EI_LDFLAGS = -L$(EI_ROOT)/obj$(TYPEMARKER)/$(TARGET)
+++EI_LDFLAGS = -L$(EI_ROOT)/obj$(TYPEMARKER)/$(TARGET) $(EI_LIB)
++ LD = @LD@
++-LDFLAGS =  $(ODBC_LIB) $(EI_LDFLAGS)
++-LIBS = @LIBS@ @THR_LIBS@ $(EI_LIB)
+++LDFLAGS =  $(EI_LDFLAGS) $(ODBC_LIB)
+++LIBS = @LIBS@ @THR_LIBS@
++ INCLUDES = -I. $(ODBC_INCLUDE) $(EI_INCLUDE)
++ TARGET_FLAGS =  @TARGET_FLAGS@
++
++--
++2.44.0
++
+-- 
+2.34.1
+

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/erlang:26.2.3-ubuntu-jammy-20240125
+FROM hexpm/erlang:26.2.4-ubuntu-jammy-20240125
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
 description="Container with everything needed to build Nerves Systems"


### PR DESCRIPTION
Updated erlang to 26.2.4.

Added patch to fix compilation errors when `libei` is present, discussed [here](https://github.com/erlang/otp/issues/8244).

This fix is merged into `master` but hasn't made it into releases yet.