### PR TITLE
Manually create skel

### DIFF
--- a/create-build.sh
+++ b/create-build.sh
@@ -67,6 +67,16 @@ if [[ $HOST_ARCH != "x86_64" ]] && [[ $HOST_ARCH != "aarch64" ]]; then
     exit 1
 fi
 
+# Check that NERVES_BUILD_DIR is on a case-sensitive filesystem
+touch case.sensitive
+touch CASE.sensitive
+if [[ "$(ls -1 $NERVES_BUILD_DIR/*.sensitive | wc -l | tr -d '[:space:]')" != "2" ]]; then
+    echo "ERROR: Build directory '$NERVES_BUILD_DIR' must be on a case-sensitive filesystem"
+    rm $NERVES_BUILD_DIR/*.sensitive
+    exit 1
+fi
+rm $NERVES_BUILD_DIR/*.sensitive
+
 # Determine the NERVES_SYSTEM source directory
 NERVES_SYSTEM=$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")
 if [[ ! -e $NERVES_SYSTEM ]]; then

--- a/support/docker/nerves_system_br/docker-entrypoint.sh
+++ b/support/docker/nerves_system_br/docker-entrypoint.sh
@@ -7,7 +7,8 @@ if [[ -n "$UID" ]] && [[ "$UID" != "0" ]] && [[ -n "$GID" ]] && [[ "$GID" != "0"
   echo "GID: $GID"
 
   groupadd -o -g "$GID" nerves
-  useradd -o -g "$GID" -u "$UID" -m nerves
+  useradd -o -g "$GID" -u "$UID" -M nerves
+  cp -pr /etc/skel/. ~nerves
 
   echo "Switching user"
 


### PR DESCRIPTION
With https://github.com/nerves-project/nerves/pull/972, `useradd` fails to copy the /etc/skel to the new home directory.
This fixes by manually doing this copy.