### PR TITLE
Bump Raspberry Pi firmware and libcamera packages

### DIFF
--- a/package/rpi-distro-bluez-firmware/rpi-distro-bluez-firmware.hash
+++ b/package/rpi-distro-bluez-firmware/rpi-distro-bluez-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  ae076a08ece89624b0449ea2495b0dfe2ea1223f683f5b57f2b89966e6a093d6  rpi-distro-bluez-firmware-d9d4741caba7314d6500f588b1eaa5ab387a4ff5.tar.gz
+sha256  56bcee9bac20720ceeef983949ba4d6b8d81c2f9602613232e642de547240841  rpi-distro-bluez-firmware-78d6a07730e2d20c035899521ab67726dc028e1c.tar.gz
 sha256  79576e5ea6740845bf71ce96ad4e31cd49797c8e1a259d64670f48554b8eb67c  debian/copyright

--- a/package/rpi-distro-bluez-firmware/rpi-distro-bluez-firmware.mk
+++ b/package/rpi-distro-bluez-firmware/rpi-distro-bluez-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_DISTRO_BLUEZ_FIRMWARE_VERSION = d9d4741caba7314d6500f588b1eaa5ab387a4ff5 # 1.2-9+rpt2
+RPI_DISTRO_BLUEZ_FIRMWARE_VERSION = 78d6a07730e2d20c035899521ab67726dc028e1c # 1.2-9+rpt3
 RPI_DISTRO_BLUEZ_FIRMWARE_SITE = $(call github,RPi-Distro,bluez-firmware,$(RPI_DISTRO_BLUEZ_FIRMWARE_VERSION))
 RPI_DISTRO_BLUEZ_FIRMWARE_LICENSE_FILES = debian/copyright
 

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  24e3392cabe8490adbea0812dafd54d42cd3f3569e1a67190fadaa4f5d15d5da  rpi-distro-firmware-nonfree-3db4164cfd89e6d9afb7ebc87607b792651512df.tar.gz
-sha256  8eac53f5b6f873de238ba57c46edffdd62c9a283d5995140f96fdd51d3145dc6  debian/copyright
+sha256  a73ecb8e4fe3e55f6919352661600538ff5fcac82cadfa4e52caf4ccf61ece58  rpi-distro-firmware-nonfree-223ccf3a3ddb11b3ea829749fbbba4d65b380897.tar.gz
+sha256  508ebd51eeb579b9d4ebed8379c411cf6d53ae663e8bb9307cbee6a53564894c  debian/copyright

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 3db4164cfd89e6d9afb7ebc87607b792651512df # 1:20230210-5+rpt3
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 223ccf3a3ddb11b3ea829749fbbba4d65b380897 # 1:20230625-2+rpt2
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/copyright
 

--- a/package/rpi-libcamera/rpi-libcamera.hash
+++ b/package/rpi-libcamera/rpi-libcamera.hash
@@ -1,4 +1,4 @@
-sha256  79e5ad20c1242fe3baa20b07054341da96b9a1a37c991d278e162c62a3b4f9db  rpi-libcamera-v0.2.0+rpt20240215.tar.gz
+sha256  c123feb1ae439f92956578076fd1c2f33f198c9b1903b55f3efed6a5a3cd0993  rpi-libcamera-v0.2.0+rpt20240418.tar.gz
 
 # license files
 sha256  fd38b2c053c0cce46d9c5ef3545a6e34d157a240ba99c9b8dca5d37a8147da6c  LICENSES/BSD-2-Clause.txt

--- a/package/rpi-libcamera/rpi-libcamera.mk
+++ b/package/rpi-libcamera/rpi-libcamera.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_LIBCAMERA_VERSION = v0.2.0+rpt20240215
+RPI_LIBCAMERA_VERSION = v0.2.0+rpt20240418
 RPI_LIBCAMERA_SITE = $(call github,raspberrypi,libcamera,$(RPI_LIBCAMERA_VERSION))
 RPI_LIBCAMERA_DEPENDENCIES = \
 	host-openssl \

--- a/package/rpicam-apps/rpicam-apps.hash
+++ b/package/rpicam-apps/rpicam-apps.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  5dd776715d08e3096922f9a67236507176220b28528beb87bbb021bdfe67fa84  rpicam-apps-1.4.3.tar.gz
+sha256  633e1f2071222dba66497d33a44e084b6759bcf537ba8cbb67aade48ea97659f  rpicam-apps-1.5.0.tar.gz
 sha256  36dfed86bdef661a0a14ec1a1cc84c771d5a06b6f9b92e9ebb610ba711bd528a  license.txt

--- a/package/rpicam-apps/rpicam-apps.mk
+++ b/package/rpicam-apps/rpicam-apps.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPICAM_APPS_VERSION = 1.4.3
+RPICAM_APPS_VERSION = 1.5.0
 RPICAM_APPS_SITE = $(call github,raspberrypi,rpicam-apps,v$(RPICAM_APPS_VERSION))
 RPICAM_APPS_LICENSE = BSD-2-Clause
 RPICAM_APPS_LICENSE_FILES = license.txt
@@ -18,21 +18,21 @@ RPICAM_APPS_DEPENDENCIES = \
 	tiff
 
 RPICAM_APPS_CONF_OPTS = \
-	-Denable_opencv=false \
-	-Denable_tflite=false
+	-Denable_opencv=disabled \
+	-Denable_tflite=disabled
 
 ifeq ($(BR2_PACKAGE_LIBDRM),y)
 RPICAM_APPS_DEPENDENCIES += libdrm
-RPICAM_APPS_CONF_OPTS += -Denable_drm=true
+RPICAM_APPS_CONF_OPTS += -Denable_drm=enabled
 else
-RPICAM_APPS_CONF_OPTS += -Denable_drm=false
+RPICAM_APPS_CONF_OPTS += -Denable_drm=disabled
 endif
 
 ifeq ($(BR2_PACKAGE_FFMPEG)$(BR2_PACKAGE_LIBDRM),yy)
 RPICAM_APPS_DEPENDENCIES += ffmpeg libdrm
-RPICAM_APPS_CONF_OPTS += -Denable_libav=true
+RPICAM_APPS_CONF_OPTS += -Denable_libav=enabled
 else
-RPICAM_APPS_CONF_OPTS += -Denable_libav=false
+RPICAM_APPS_CONF_OPTS += -Denable_libav=disabled
 endif
 
 ifeq ($(BR2_PACKAGE_XORG7),y)
@@ -43,9 +43,9 @@ endif
 
 ifeq ($(BR2_PACKAGE_QT5),y)
 RPICAM_APPS_DEPENDENCIES += qt5base
-RPICAM_APPS_CONF_OPTS += -Denable_qt=true
+RPICAM_APPS_CONF_OPTS += -Denable_qt=enabled
 else
-RPICAM_APPS_CONF_OPTS += -Denable_qt=false
+RPICAM_APPS_CONF_OPTS += -Denable_qt=disabled
 endif
 
 ifeq ($(BR2_TOOLCHAIN_HAS_LIBATOMIC),y)


### PR DESCRIPTION
- **rpi-distro-bluez-firmware: bump to 78d6a07**
- **rpi-distro-firmware-nonfree: bump version to 20230625-2+rpi2**
- **rpi-libcamera: bump to v0.2.0+rpt20240418**
- **rpicam-apps: bump to 1.4.4**
