### PR TITLE
Don't fail on rm *.sensitive if it was already removed earlier in script

### DIFF
--- a/create-build.sh
+++ b/create-build.sh
@@ -94,7 +94,7 @@ if [[ "$(find "$NERVES_BUILD_DIR" -name "*.sensitive" | wc -l | tr -d '[:space:]
             "
     fi
 fi
-rm "$NERVES_BUILD_DIR"/*.sensitive
+rm -f "$NERVES_BUILD_DIR"/*.sensitive
 
 # Determine the NERVES_SYSTEM source directory
 NERVES_SYSTEM=$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")


### PR DESCRIPTION
The rm *.sensitive done here can fail if it was previously removed (on line 74). The script is running with `set -e` so this will cause the script to exit unexpectedly. Adding a `-f` to the rm will fix it