### PR TITLE
Update Dockerfile for better non-root use

### DIFF
--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,15 +1,44 @@
 FROM hexpm/erlang:27.0-ubuntu-jammy-20240530
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
-description="Container with everything needed to build Nerves Systems"
+      description="Container with everything needed to build Nerves Systems"
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-ENV DEBIAN_FRONTEND noninteractive
 ENV FWUP_VERSION=1.10.0
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+
+# See https://github.com/CircleCI-Public/cimg-base/blob/main/Dockerfile.template for generic setup
+
+# Change default shell for RUN from Dash to Bash
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=dumb \
+    PAGER=cat
+
+# Configure environment
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90nerves && \
+	echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90nerves && \
+	apt-get update && apt-get install -y \
+		curl \
+		locales \
+		sudo \
+	&& \
+	locale-gen en_US.UTF-8 && \
+	rm -rf /var/lib/apt/lists/* && \
+	\
+	groupadd --gid=1005 nerves && \
+	useradd --uid=1005 --gid=nerves --create-home nerves && \
+	echo 'nerves ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-nerves && \
+	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
+	sudo -u nerves mkdir /home/nerves/project && \
+	sudo -u nerves mkdir /home/nerves/bin && \
+	sudo -u nerves mkdir -p /home/nerves/.local/bin
+
+ENV PATH=/home/nerves/bin:/home/nerves/.local/bin:$PATH \
+	LANG=C.UTF-8 \
+	LC_ALL=C.UTF-8
 
 COPY setup-packages.sh /nerves/setup-packages.sh
 RUN chmod +x /nerves/setup-packages.sh
@@ -26,15 +55,15 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8 C.UTF-8/' /etc/locale.gen
 RUN /nerves/setup-packages.sh && apt-get update -y -qq
 
 # Install our i386 deps first, since they require special config in aarch64 envs
-RUN apt-get install -y \
+RUN apt-get -o APT::Retries=3 install -y --no-install-recommends \
         libc6:i386 \
         libncurses5:i386 \
         gcc-multilib \
         g++-multilib \
         libstdc++6:i386
 
-RUN apt-get install -y --no-install-recommends \
-    # Install Buildroot packages (see <Buildroot>/support/docker/DockerFile
+# Install Buildroot packages (see <Buildroot>/support/docker/DockerFile
+RUN apt-get -o APT::Retries=3 install -y --no-install-recommends \
     bc \
     build-essential \
     bzr \
@@ -47,20 +76,22 @@ RUN apt-get install -y --no-install-recommends \
     git \
     libncurses5-dev \
     locales \
-    mercurial-common \
+    mercurial \
+    openssh-server \
     python3 \
-    python3-aiohttp \
     python3-flake8 \
-    python3-ijson \
+    python3-magic \
     python3-nose2 \
     python3-pexpect \
-    python3-pip \
-    python3-requests \
+    python3-pytest \
     rsync \
+    shellcheck \
     subversion \
     unzip \
-    wget \
-    # Install additional packages for Nerves and fwup
+    wget
+
+# Install additional packages for Nerves and fwup
+RUN apt-get -o APT::Retries=3 install -y --no-install-recommends \
     bzip2 \
     curl \
     gawk \
@@ -73,33 +104,45 @@ RUN apt-get install -y --no-install-recommends \
     libssl-dev \
     openssh-client \
     pkg-config \
+    python3-aiohttp \
+    python3-ijson \
+    python3-pip \
+    python3-requests \
     squashfs-tools \
     xz-utils \
     autoconf \
     automake \
     libtool \
     libarchive-dev \
-    libconfuse-dev \
-    # Install packages to make image easier to use
-    sudo \
-    vim-tiny
+    libconfuse-dev
 
-RUN rm -rf /var/lib/apt/lists/* \
-  && mkdir -p /root/.ssh \
-  && ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts \
-  && chmod 700 /root/.ssh \
-  && chmod 600 /root/.ssh/known_hosts \
-  && rm -rf /var/lib/apt/lists/* \
+# Install packages to make image easier to use
+RUN apt-get -o APT::Retries=3 install -y --no-install-recommends \
+    sudo \
+    vim-tiny \
   && apt-get -q -y autoremove \
   && apt-get -q -y clean \
-  && mkdir -p /nerves/build && chmod 777 /nerves/build
+  && rm -rf var/lib/apt/lists/*
 
 # Build fwup from source for the current architecture
-RUN git clone https://github.com/fwup-home/fwup -b v${FWUP_VERSION} && cd fwup && ./autogen.sh && ./configure && make && make install
-RUN rm -rf fwup
+RUN git clone https://github.com/fwup-home/fwup -b v${FWUP_VERSION} \
+  && cd fwup \
+  && ./autogen.sh \
+  && ./configure \
+  && make \
+  && make install \
+  && rm -rf fwup
 
 # Switch to a non-root user
-RUN useradd -ms /bin/bash nerves
 USER nerves
-RUN whoami
-WORKDIR /home/nerves
+RUN whoami \
+  # opt-out of the new security feature, not needed in a CI environment
+  && git config --global --add safe.directory '*'
+
+# Cache GitHub's host key
+RUN mkdir -p /home/nerves/.ssh \
+  && ssh-keyscan github.com > /home/nerves/.ssh/known_hosts \
+  && chmod 700 /home/nerves/.ssh \
+  && chmod 600 /home/nerves/.ssh/known_hosts
+
+WORKDIR /home/nerves/project


### PR DESCRIPTION
This pulls in many improvements from
https://github.com/CircleCI-Public/cimg-base/blob/main/Dockerfile.template
to address non-root use.

The most important of these are adding `./.local/bin` to the PATH and
password-less sudo. Others include environment variable updates, fixing
the cached ssh host key path and other improvements from the CircleCI
template.
