### PR TITLE
Run unsquashfs with force flag when merging rootfs

### DIFF
--- a/scripts/merge-squashfs
+++ b/scripts/merge-squashfs
@@ -190,7 +190,7 @@ find_to_pseudofile "$overlay_dir" >>pseudofile.in
 # remove repeated entries to avoid warnings from mksquashfs
 awk '!x[$1]++' pseudofile.in > pseudofile
 
-unsquashfs "$input_squashfs" >/dev/null
+unsquashfs -f "$input_squashfs" >/dev/null
 cp -Rf "$overlay_dir/." "$workdir/squashfs-root"
 mksquashfs squashfs-root "$output_squashfs" -pf pseudofile -sort "$squashfs_priorities" -noappend -no-recovery -no-progress $NERVES_MKSQUASHFS_FLAGS
 


### PR DESCRIPTION
This is a temporary fix for an issue that prevents building firmware on
macOS if the Nerves system contains any files with names that collide on
a case-insensitive filesystem like APFS. See nerves-project/nerves#876.

When running `mix firmware`, warnings in the following format may
indicate that some things may not work as expected:

```
Pseudo modify file "path/to/file" does not exist in source filesystem.  Ignoring.
```
