### PR TITLE
Update scrub warning to be more helpful

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -149,17 +149,13 @@ for EXECUTABLE in $EXECUTABLES; do
             echo
             echo "Check the following:"
             echo
-            echo "1. Are you using a path dependency in your mix deps? If so, run"
+            echo "1. If this file comes from a library, that library may be compiling to"
+            echo "   its source directory under `deps`. Manually clean up the source"
+            echo "   directory and try building again."
+            echo
+            echo "2. Are you using a path dependency in your mix deps? If so, run"
             echo "   'mix clean' in that directory to avoid pulling in any of its"
             echo "   build products."
-            echo
-            echo "2. Did you recently upgrade to Elixir 1.9 or Nerves 1.5?"
-            echo "   Nerves 1.5 adds support for Elixir 1.9 Releases and requires"
-            echo "   you to either add an Elixir 1.9 Release configuration or add"
-            echo "   Distillery as a dependency. Without this, the OTP binaries"
-            echo "   for your build machine will get included incorrectly and cause"
-            echo "   this error. See"
-            echo "   https://hexdocs.pm/nerves/updating-projects.html#updating-from-v1-4-to-v1-5"
             echo
             echo "3. Did you recently upgrade or change your Nerves system? If so,"
             echo "   try cleaning and rebuilding this project and its deps."


### PR DESCRIPTION
The Elixir versioning reason is super old, and hopefully we're years
past anyone running into that.

Nowadays, it seems way more common to run into libraries that build to their
source directories and don't do the right thing when the `MIX_TARGET`
changes.
