### PR TITLE
Ensure executables are writable before stripping

### DIFF
--- a/scripts/scrub-otp-release.sh
+++ b/scripts/scrub-otp-release.sh
@@ -175,6 +175,7 @@ for EXECUTABLE in $EXECUTABLES; do
 
         # Strip debug information from ELF binaries
         # Symbols are still available to the user in the release directory.
+        chmod +w "$EXECUTABLE"
         if ! $STRIP "$EXECUTABLE"; then
             echo "WARNING: Can't remove debug symbols from $EXECUTABLE. This is expected for precompiled Rust."
         fi


### PR DESCRIPTION
It turns out that the XLA shared libraries are marked read-only and
because of this, they fail to be stripped. This unconditionally marks
executables as writable before stripping them to avoid this being a
reason to error out.
