### PR TITLE
Add TPM support

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -38,6 +38,7 @@ source "$BR2_EXTERNAL_NERVES_PATH/package/rpicam-apps/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/rpi-distro-bluez-firmware/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/rpi-distro-firmware-nonfree/Config.in"
 source "$BR2_EXTERNAL_NERVES_PATH/package/rpi-libcamera/Config.in"
+source "$BR2_EXTERNAL_NERVES_PATH/package/tpm2-tss-engine/Config.in"
 
 # Load user options
 menu "User-provided options"

--- a/package/tpm2-tss-engine/0001-Allow-disabling-of-digest-sign-operations.patch
+++ b/package/tpm2-tss-engine/0001-Allow-disabling-of-digest-sign-operations.patch
@@ -1,0 +1,42 @@
+From af8b26e7ffe69837197fb841e9a31230ae01c9cc Mon Sep 17 00:00:00 2001
+From: Andreas Fuchs <andreas.fuchs@infineon.com>
+Date: Mon, 22 May 2023 14:06:41 +0200
+Subject: [PATCH] Configure: Allow disabling of digest-sign operations
+
+Since the digest-sign operations perform the hash on the TPM and
+TPMs in general do not support SHA512, this can lead to errors.
+Depending on the use case, it might be preferable to not support
+restricted keys (via digest+sign) but to rely on ordinary keys
+only.
+
+Signed-off-by: Andreas Fuchs <andreas.fuchs@infineon.com>
+---
+ configure.ac | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d4a9356..b379042 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -116,13 +116,19 @@ PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 1.0.2g],
+ PKG_CHECK_MODULES([TSS2_ESYS], [tss2-esys >= 2.3])
+ PKG_CHECK_MODULES([TSS2_MU], [tss2-mu])
+ PKG_CHECK_MODULES([TSS2_TCTILDR], [tss2-tctildr])
++
+ AC_CHECK_LIB([crypto], EC_KEY_METHOD_set_compute_key,
+       [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], true)],
+       [AM_CONDITIONAL([HAVE_OPENSSL_ECDH], false)])
++
++AC_ARG_ENABLE([digestsign],
++              [AS_HELP_STRING([--disable-digestsign],
++                              [Disable support for digest and sign methods, helps with TPM unsupported hash algorithms.])],,
++              [enable_digestsign=yes])
+ AC_CHECK_LIB([crypto], EVP_PKEY_meth_set_digest_custom,
+-      [AM_CONDITIONAL([HAVE_OPENSSL_DIGEST_SIGN], true)],
++      [AM_CONDITIONAL([HAVE_OPENSSL_DIGEST_SIGN], [test "x$enable_digestsign" != "xno"])],
+       [AM_CONDITIONAL([HAVE_OPENSSL_DIGEST_SIGN], false)])
+-AS_IF([test "x$ac_cv_lib_crypto_EVP_PKEY_meth_set_digest_custom" = xyes],
++AS_IF([test "x$ac_cv_lib_crypto_EVP_PKEY_meth_set_digest_custom" = xyes && test "x$enable_digestsign" = "xyes"],
+       [AC_DEFINE([HAVE_OPENSSL_DIGEST_SIGN], [1],
+                  Have required functionality from OpenSSL to support digest and sign)])
+ 

--- a/package/tpm2-tss-engine/0002-Fix-mismatch-of-OpenSSL-function-signatures-that-cause-errors-with-gcc-14.patch
+++ b/package/tpm2-tss-engine/0002-Fix-mismatch-of-OpenSSL-function-signatures-that-cause-errors-with-gcc-14.patch
@@ -1,0 +1,71 @@
+From 766505bf5c943c614fd246d27d1e5cd66543250b Mon Sep 17 00:00:00 2001
+From: Matthias Gerstner <matthias.gerstner@suse.de>
+Date: Mon, 6 May 2024 16:07:54 +0200
+Subject: [PATCH] Fix mismatch of OpenSSL function signatures that cause errors
+ with gcc-14
+
+Building with gcc-14 fails with diagnostics like this:
+
+```
+src/tpm2-tss-engine-rsa.c:805:46: error: passing argument 2 of 'EVP_PKEY_meth_set_copy' from incompatible pointer type [-Wincompatible-pointer-types]
+  805 |     EVP_PKEY_meth_set_copy(pkey_rsa_methods, rsa_pkey_copy);
+      |                                              ^~~~~~~~~~~~~
+      |                                              |
+      |                                              int (*)(EVP_PKEY_CTX *, EVP_PKEY_CTX *) {aka int (*)(struct evp_pkey_ctx_st *, struct evp_pkey_ctx_st *)}
+/usr/include/openssl/evp.h:2005:36: note: expected 'int (*)(EVP_PKEY_CTX *, const EVP_PKEY_CTX *)' {aka 'int (*)(struct evp_pkey_ctx_st *, const struct evp_pkey_ctx_st *)'} but argument is of type 'int (*)(EVP_PKEY_CTX *, EVP_PKEY_CTX *)' {aka 'int (*)(struct evp_pkey_ctx_st *, struct evp_pkey_ctx_st *)'}
+```
+
+A look into OpenSSL upstream shows that these functions have always had const
+`src` parameters. Thus this error was simply not detected by earlier compiler
+versions.
+
+Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>
+---
+ src/tpm2-tss-engine-ecc.c | 4 ++--
+ src/tpm2-tss-engine-rsa.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/tpm2-tss-engine-ecc.c b/src/tpm2-tss-engine-ecc.c
+index 9e72c85..f6b9c5a 100644
+--- a/src/tpm2-tss-engine-ecc.c
++++ b/src/tpm2-tss-engine-ecc.c
+@@ -52,7 +52,7 @@ EC_KEY_METHOD *ecc_methods = NULL;
+ #endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
+ 
+ #ifdef HAVE_OPENSSL_DIGEST_SIGN
+-static int (*ecdsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src);
++static int (*ecdsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
+ static void (*ecdsa_pkey_orig_cleanup)(EVP_PKEY_CTX *ctx);
+ #endif /* HAVE_OPENSSL_DIGEST_SIGN */
+ 
+@@ -405,7 +405,7 @@ ecdsa_ec_key_sign(const unsigned char *dgst, int dgst_len, const BIGNUM *inv,
+ 
+ #ifdef HAVE_OPENSSL_DIGEST_SIGN
+ static int
+-ecdsa_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
++ecdsa_pkey_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
+ {
+     if (ecdsa_pkey_orig_copy && !ecdsa_pkey_orig_copy(dst, src))
+         return 0;
+diff --git a/src/tpm2-tss-engine-rsa.c b/src/tpm2-tss-engine-rsa.c
+index 41de34e..e7260c2 100644
+--- a/src/tpm2-tss-engine-rsa.c
++++ b/src/tpm2-tss-engine-rsa.c
+@@ -49,7 +49,7 @@ RSA_METHOD *rsa_methods = NULL;
+ #endif /* OPENSSL_VERSION_NUMBER < 0x10100000 */
+ 
+ #ifdef HAVE_OPENSSL_DIGEST_SIGN
+-static int (*rsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src);
++static int (*rsa_pkey_orig_copy)(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
+ static void (*rsa_pkey_orig_cleanup)(EVP_PKEY_CTX *ctx);
+ #endif /* HAVE_OPENSSL_DIGEST_SIGN */
+ 
+@@ -637,7 +637,7 @@ RSA_METHOD rsa_methods = {
+ 
+ #ifdef HAVE_OPENSSL_DIGEST_SIGN
+ static int
+-rsa_pkey_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
++rsa_pkey_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
+ {
+     if (rsa_pkey_orig_copy && !rsa_pkey_orig_copy(dst, src))
+         return 0;

--- a/package/tpm2-tss-engine/Config.in
+++ b/package/tpm2-tss-engine/Config.in
@@ -1,0 +1,10 @@
+config BR2_PACKAGE_TPM2_TSS_ENGINE
+	bool "tpm2-tss-engine"
+	select BR2_PACKAGE_TPM2_TSS
+	help
+	  The tpm2-tss-engine project implements a cryptographic engine for
+	  OpenSSL for Trusted Platform Module (TPM 2.0) using the tpm2-tss
+	  software stack that follows the Trusted Computing Groups (TCG)
+	  TPM Software Stack (TSS 2.0). It uses the Enhanced System API (ESAPI)
+	  interface of the TSS 2.0 for downwards communication. It supports
+	  RSA decryption and signatures as well as ECDSA signatures.

--- a/package/tpm2-tss-engine/tpm2-tss-engine.hash
+++ b/package/tpm2-tss-engine/tpm2-tss-engine.hash
@@ -1,0 +1,1 @@
+sha256  3c94fef110dd3630b3c28c5875febba76b7d5ba2fcc04a14c4a30f5d2157c265  tpm2-tss-engine-1.2.0.tar.gz

--- a/package/tpm2-tss-engine/tpm2-tss-engine.mk
+++ b/package/tpm2-tss-engine/tpm2-tss-engine.mk
@@ -1,0 +1,20 @@
+################################################################################
+#
+# tpm2-tss-engine
+#
+################################################################################
+
+TPM2_TSS_ENGINE_VERSION = 1.2.0
+TPM2_TSS_ENGINE_SITE = https://github.com/tpm2-software/tpm2-tss-engine/releases/download/$(TPM2_TSS_ENGINE_VERSION)
+TPM2_TSS_ENGINE_SOURCE = tpm2-tss-engine-$(TPM2_TSS_ENGINE_VERSION).tar.gz
+TPM2_TSS_ENGINE_LICENSE = BSD-3-Clause
+TPM2_TSS_ENGINE_LICENSE_FILES = LICENSE
+TPM2_TSS_ENGINE_INSTALL_STAGING = YES
+TPM2_TSS_ENGINE_DEPENDENCIES = host-pkgconf tpm2-tss
+TPM2_TSS_ENGINE_AUTORECONF = YES
+
+TPM2_TSS_ENGINE_CONF_OPTS = \
+	--disable-digestsign \
+	--with-enginesdir="/usr/lib/engines-3"
+
+$(eval $(autotools-package))

--- a/patches/buildroot/0016-update-tpm2-tss-to-4.1.3.patch
+++ b/patches/buildroot/0016-update-tpm2-tss-to-4.1.3.patch
@@ -1,0 +1,95 @@
+From 2773b8349084b61bd5099380142edb8c119bd206 Mon Sep 17 00:00:00 2001
+From: Alex McLain <alex@alexmclain.com>
+Date: Tue, 5 Nov 2024 11:05:52 -0800
+Subject: [PATCH 1/2] update tpm2-tss to 4.1.3
+
+---
+ ...01-Temporary-fix-for-build-without-C.patch | 44 -------------------
+ package/tpm2-tss/tpm2-tss.hash                |  2 +-
+ package/tpm2-tss/tpm2-tss.mk                  |  4 +-
+ 3 files changed, 3 insertions(+), 47 deletions(-)
+ delete mode 100644 package/tpm2-tss/0001-Temporary-fix-for-build-without-C.patch
+
+diff --git a/package/tpm2-tss/0001-Temporary-fix-for-build-without-C.patch b/package/tpm2-tss/0001-Temporary-fix-for-build-without-C.patch
+deleted file mode 100644
+index 812c753ffb..0000000000
+--- a/package/tpm2-tss/0001-Temporary-fix-for-build-without-C.patch
++++ /dev/null
+@@ -1,44 +0,0 @@
+-From 7dc753ad27a8cd14c9b00be94ca89b847cf05ce9 Mon Sep 17 00:00:00 2001
+-From: Carlos Santos <unixmania@gmail.com>
+-Date: Mon, 23 Dec 2019 08:02:19 -0300
+-Subject: [PATCH] Temporary fix for build without C++
+-
+-C++ is required only for the fuzzing tests but AC_PROG_CXX is included
+-by configure.ac even when fuzzing is not enabled (which we don't do on
+-Buildroot).
+-
+-The patch applied upstream had issues and was reverted[1]. Use a local
+-patch to solve the problem temporaryly.
+-
+-Fixes:
+-    http://autobuild.buildroot.net/results/13f5e37b47b255da4158bec34e5459136f7e60d4
+-    http://autobuild.buildroot.net/results/1c26db2509c79e00c0de1165945277eaa57b149f
+-    http://autobuild.buildroot.net/results/b7b6b7b7aca79e847b442cbd2305427d91fe5d70
+-    http://autobuild.buildroot.net/results/1cd5a82a0e799aa5027e2e2c03b246332cc3a15d
+-    http://autobuild.buildroot.net/results/d7ec878907f714377c83e9a496e97cbf9382d787
+-    http://autobuild.buildroot.net/results/1c7f0c1b3ce4871cd87bd6059b1f0a6dc4e74a9c
+-    http://autobuild.buildroot.net/results/196b81d580325607c8da90beeb79e1f6b8ab8b47
+-    http://autobuild.buildroot.net/results/f90f7b4ac710b56686635f8ae27059c11b963e47
+-
+-1. https://github.com/tpm2-software/tpm2-tss/commit/60c26e4c4faba6ba12469485653e17092b510840
+-
+-Signed-off-by: Carlos Santos <unixmania@gmail.com>
+----
+- configure.ac | 1 -
+- 1 file changed, 1 deletion(-)
+-
+-diff --git a/configure.ac b/configure.ac
+-index ff59dd7c..3e4028fb 100755
+---- a/configure.ac
+-+++ b/configure.ac
+-@@ -26,7 +26,6 @@ AX_IS_RELEASE(dash-version)
+- AX_CHECK_ENABLE_DEBUG([info])
+- 
+- AC_PROG_CC
+--AC_PROG_CXX
+- AC_PROG_LN_S
+- AC_USE_SYSTEM_EXTENSIONS
+- LT_INIT()
+--- 
+-2.26.2
+-
+diff --git a/package/tpm2-tss/tpm2-tss.hash b/package/tpm2-tss/tpm2-tss.hash
+index c9fa4e6ae0..891c1285b0 100644
+--- a/package/tpm2-tss/tpm2-tss.hash
++++ b/package/tpm2-tss/tpm2-tss.hash
+@@ -1,3 +1,3 @@
+ # Locally computed:
+-sha256  ba9e52117f254f357ff502e7d60fce652b3bfb26327d236bbf5ab634235e40f1  tpm2-tss-3.2.2.tar.gz
++sha256  37f1580200ab78305d1fc872d89241aaee0c93cbe85bc559bf332737a60d3be8  tpm2-tss-4.1.3.tar.gz
+ sha256  18c1bf4b1ba1fb2c4ffa7398c234d83c0d55475298e470ae1e5e3a8a8bd2e448  LICENSE
+diff --git a/package/tpm2-tss/tpm2-tss.mk b/package/tpm2-tss/tpm2-tss.mk
+index b76d16e71e..09c6eaede0 100644
+--- a/package/tpm2-tss/tpm2-tss.mk
++++ b/package/tpm2-tss/tpm2-tss.mk
+@@ -4,14 +4,14 @@
+ #
+ ################################################################################
+ 
+-TPM2_TSS_VERSION = 3.2.2
++TPM2_TSS_VERSION = 4.1.3
+ TPM2_TSS_SITE = https://github.com/tpm2-software/tpm2-tss/releases/download/$(TPM2_TSS_VERSION)
+ TPM2_TSS_LICENSE = BSD-2-Clause
+ TPM2_TSS_LICENSE_FILES = LICENSE
+ TPM2_TSS_CPE_ID_VENDOR = tpm2_software_stack_project
+ TPM2_TSS_CPE_ID_PRODUCT = tpm2_software_stack
+ TPM2_TSS_INSTALL_STAGING = YES
+-TPM2_TSS_DEPENDENCIES = openssl host-pkgconf
++TPM2_TSS_DEPENDENCIES = openssl host-pkgconf util-linux
+ 
+ # 0001-configure-Only-use-CXX-when-fuzzing.patch
+ TPM2_TSS_AUTORECONF = YES
+-- 
+2.34.1
+


### PR DESCRIPTION
This PR contains a few modifications for a [Trusted Platform Module](https://en.wikipedia.org/wiki/Trusted_Platform_Module) (TPM) to work with Nerves:

- The `tpm2-tss-engine` package was added so that the BEAM can communicate with the TPM via an OpenSSL engine.
- `tpm2-tss` is a core library for communicating with TPMs. v3 was incompatible, so we patched it to v4.
- We pulled in a patch to support compilation with GCC 14.

The Elixir TPM library is available here:
https://github.com/redwirelabs/tpm

This is also compatible with the open source [tpm2-tools](https://github.com/tpm2-software/tpm2-tools) tooling.
