### PR TITLE
erlinit: bump to 1.14.2

### DIFF
--- a/package/erlinit/erlinit.hash
+++ b/package/erlinit/erlinit.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256 a2d366ddac6801bd6a4be3f7cfa3739914300a5c1515258aac46ab09839e4958  erlinit-v1.14.1.tar.gz
+sha256 3ff1762bcd6defe94be41b6f753b9f324d78fa5ef6be8808c471c4bf8a34527e  erlinit-v1.14.2.tar.gz
 sha256 a313bcd5f17638d66753aa15c9fbe52a955be2e07e1a4ec880e8d4acb8098438  LICENSE

--- a/package/erlinit/erlinit.mk
+++ b/package/erlinit/erlinit.mk
@@ -4,7 +4,7 @@
 #
 #############################################################
 
-ERLINIT_VERSION = v1.14.1
+ERLINIT_VERSION = v1.14.2
 ERLINIT_SITE = $(call github,nerves-project,erlinit,$(ERLINIT_VERSION))
 ERLINIT_LICENSE = MIT
 ERLINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This version adds the `--core-pattern` option.
