### PR TITLE
rpi-distro-firmware-nonfree: bump to 1:20230625-2+rpt3

### DIFF
--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  a73ecb8e4fe3e55f6919352661600538ff5fcac82cadfa4e52caf4ccf61ece58  rpi-distro-firmware-nonfree-223ccf3a3ddb11b3ea829749fbbba4d65b380897.tar.gz
+sha256  41783dd15e21f591eb65d47bd013eba4c1bfccd6f52a43963b8971f32e89190b  rpi-distro-firmware-nonfree-a6ed59a078d52ad72f0f2b99e68f324e7411afa1.tar.gz
 sha256  508ebd51eeb579b9d4ebed8379c411cf6d53ae663e8bb9307cbee6a53564894c  debian/copyright

--- a/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
+++ b/package/rpi-distro-firmware-nonfree/rpi-distro-firmware-nonfree.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_DISTRO_FIRMWARE_NONFREE_VERSION = 223ccf3a3ddb11b3ea829749fbbba4d65b380897 # 1:20230625-2+rpt2
+RPI_DISTRO_FIRMWARE_NONFREE_VERSION = a6ed59a078d52ad72f0f2b99e68f324e7411afa1 # 1:20230625-2+rpt3 + CM5/500 symlinks
 RPI_DISTRO_FIRMWARE_NONFREE_SITE = $(call github,RPi-Distro,firmware-nonfree,$(RPI_DISTRO_FIRMWARE_NONFREE_VERSION))
 RPI_DISTRO_FIRMWARE_NONFREE_LICENSE_FILES = debian/copyright
 


### PR DESCRIPTION
This also includes symlinks for the CM5 and 500.

The changelog reads:

```
  [ Phil Elwell ]
  * brcm80211: cypress: Add 43455 firmware for WPA3 offload
  [ Serge Schneider ]
  * d/c/brcm80211/defines: update version
  * Update linux-support to 6.6.31+rpt
```
