### PR TITLE
Include Erlang patch to correctly alarm on low memory

### DIFF
--- a/patches/buildroot/0017-erlang-use-available-memory-for-used-memory-calculat.patch
+++ b/patches/buildroot/0017-erlang-use-available-memory-for-used-memory-calculat.patch
@@ -1,0 +1,98 @@
+From 7227bc07b695874a3c7c1bca28fa1de7493dd8c2 Mon Sep 17 00:00:00 2001
+From: Frank Hunleth <fhunleth@troodon-software.com>
+Date: Mon, 7 Jul 2025 14:23:04 -0400
+Subject: [PATCH] erlang: use available memory for used memory calculation
+
+---
+ ...able-memory-on-Linux-for-used-memory.patch | 79 +++++++++++++++++++
+ 1 file changed, 79 insertions(+)
+ create mode 100644 package/erlang/27.3.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+
+diff --git a/package/erlang/27.3.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch b/package/erlang/27.3.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+new file mode 100644
+index 0000000000..9922e5c58d
+--- /dev/null
++++ b/package/erlang/27.3.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+@@ -0,0 +1,79 @@
++From 3ee931e8acf916653bdc329f0543d415ccdc7326 Mon Sep 17 00:00:00 2001
++From: Frank Hunleth <fhunleth@troodon-software.com>
++Date: Sat, 5 Jul 2025 21:47:29 -0400
++Subject: [PATCH] memsup: use available memory on Linux for used memory
++ calculation
++
++This updates `get_basic_mem` to improve the used memory calculation on
++Linux since the less accurate `__SC_AVPHYS_PAGES` code started being
++used.
++
++Since Linux is quick to use available DRAM as a filesystem cache, the
++`system_memory_high_watermark` alarm was getting set even though there
++was plenty of memory.
++
++Since `memsup:get_memory_data()` returns the values checked for the
++alarm, the following shows why the alarm was incorrectly set. In it, it
++shows about 222 MB out of 254 MB in use, but if you look at the
++`available_memory`, there's more like 254 MB - 114 MB = 140 MB in use.
++
++```
++> memsup:get_memory_data().
++{254287872, 222711808, {<0.3654.0>, 3819324}}
++> memsup:get_system_memory_data().
++[{available_memory,114470912},
++ {buffered_memory,139264},
++ {cached_memory,89665536},
++ {free_memory,33357824},
++ {free_swap,0},
++ {system_total_memory,254287872},
++ {total_memory,254287872},
++ {total_swap,0}]
++```
++
++With the change, the second element from `get_memory_data()` is much
++lower since it subtracts `available_memory` and the memory threshold
++isn't exceeded.
++---
++ lib/os_mon/c_src/memsup.c | 18 +++++++++---------
++ 1 file changed, 9 insertions(+), 9 deletions(-)
++
++diff --git a/lib/os_mon/c_src/memsup.c b/lib/os_mon/c_src/memsup.c
++index 2e9f337070..1e80e4beb3 100644
++--- a/lib/os_mon/c_src/memsup.c
+++++ b/lib/os_mon/c_src/memsup.c
++@@ -493,15 +493,7 @@ get_extended_mem(memory_ext *me) {
++ 
++ static void 
++ get_basic_mem(unsigned long *tot, unsigned long *used, unsigned long *pagesize){
++-#if defined(_SC_AVPHYS_PAGES)	/* Does this exist on others than Solaris2? */
++-    unsigned long avPhys, phys, pgSz;
++-    
++-    phys = sysconf(_SC_PHYS_PAGES);
++-    avPhys = sysconf(_SC_AVPHYS_PAGES);
++-    *used = (phys - avPhys);
++-    *tot = phys;
++-    *pagesize = sysconf(_SC_PAGESIZE);
++-#elif defined(__linux__) && !defined(_SC_AVPHYS_PAGES)
+++#if defined(__linux__)
++     memory_ext me;
++     if (get_mem_procfs(&me) < 0) {
++         print_error("ProcFS read error");
++@@ -514,6 +506,14 @@ get_basic_mem(unsigned long *tot, unsigned long *used, unsigned long *pagesize){
++     } else {
++         *used = me.total - me.free;
++     }
+++#elif defined(_SC_AVPHYS_PAGES)
+++    unsigned long avPhys, phys, pgSz;
+++    
+++    phys = sysconf(_SC_PHYS_PAGES);
+++    avPhys = sysconf(_SC_AVPHYS_PAGES);
+++    *used = (phys - avPhys);
+++    *tot = phys;
+++    *pagesize = sysconf(_SC_PAGESIZE);
++ #elif defined(BSD4_4)
++     struct vmtotal vt;
++     long pgsz;
++-- 
++2.43.0
++
+-- 
+2.43.0
+


### PR DESCRIPTION
This has been submitted upstream, but is here as well to get rid of
incorrect low memory alarms.
