### PR TITLE
Fine-tune check against running nerves-env.sh directly

### DIFF
--- a/nerves-env.sh
+++ b/nerves-env.sh
@@ -43,16 +43,12 @@ fi
 
 # Detect if this script has been run directly rather than sourced, since
 # that won't work.
-if [[ "$SHELL" = "/bin/bash" ]]; then
-    if [[ "$0" != "bash" && "$0" != "-bash" && "$0" != "/bin/bash" ]]; then
-        echo ERROR: This scripted should be sourced from bash:
-        echo
-        echo source "${BASH_SOURCE[@]}"
-        echo
-        exit 1
-    fi
-#elif [[ "$SHELL" = "/bin/zsh" ]]; then
-# TODO: Figure out how to detect this error from other shells.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo ERROR: This script should be sourced, not executed directly:
+    echo
+    echo source "${BASH_SOURCE[@]}"
+    echo
+    exit 1
 fi
 
 # Determine the location of the NERVES_SYSTEM directory. This script is


### PR DESCRIPTION
Since you can't just source nerves-env.sh directly to test this I made a script to verify the behavior separately:

```bash
# scripts/scratch.sh
#!/usr/bin/env bash

# Reproduces the sourced-vs-executed detection from nerves-env.sh

echo "SHELL=$SHELL"
echo "\$0=$0"
echo "BASH_SOURCE=${BASH_SOURCE[0]}"

if [[ "$SHELL" = "/bin/bash" ]]; then
    if [[ "$0" != "bash" && "$0" != "-bash" && "$0" != "/bin/bash" ]]; then
        echo "RESULT: Current check says ERROR (thinks you ran it directly)"
    else
        echo "RESULT: Current check says OK"
    fi
fi

if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
    echo "RESULT: Proposed check says ERROR (thinks you ran it directly)"
else
    echo "RESULT: Proposed check says OK (sourced)"
fi
```

Result when sourcing:
```
$ source scripts/scratch.sh
SHELL=/bin/bash
$0=/bin/bash
BASH_SOURCE=scripts/scratch.sh
RESULT: Current check says OK
RESULT: Proposed check says OK (sourced)
```

Made a small script for sourcing it from a script:
```bash
# bla.sh
#!/bin/bash

source ./scripts/scratch.sh
```

Result when running script that sources it:

```
$ ./bla.sh 
SHELL=/bin/bash
$0=./bla.sh
BASH_SOURCE=./scripts/scratch.sh
RESULT: Current check says ERROR (thinks you ran it directly)
RESULT: Proposed check says OK (sourced)
```

Result when attempting to run it directly:
```
$ ./scripts/scratch.sh 
SHELL=/bin/bash
$0=./scripts/scratch.sh
BASH_SOURCE=./scripts/scratch.sh
RESULT: Current check says ERROR (thinks you ran it directly)
RESULT: Proposed check says ERROR (thinks you ran it directly)
```