### PR TITLE
erlang: bump OTP patch releases

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: CC0-1.0
-erlang 28.4.1
+erlang 28.4.2

--- a/patches/buildroot/0007-erlang-support-OTP-21-28.patch
+++ b/patches/buildroot/0007-erlang-support-OTP-21-28.patch
@@ -53,10 +53,10 @@ Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>
  create mode 100644 package/erlang/24.3.2/0004-disksup-update-df-call-to-work-with-Busybox.patch
  create mode 100644 package/erlang/25.3.2/0001-erts-emulator-reorder-inclued-headers-paths.patch
  create mode 100644 package/erlang/25.3.2/0003-disksup-update-df-call-to-work-with-Busybox.patch
- create mode 100644 package/erlang/26.2.5/0001-disksup-update-df-call-to-work-with-Busybox.patch
- create mode 100644 package/erlang/26.2.5/0002-erlang-libei-arch-compile.patch
- create mode 100644 package/erlang/27.3.4.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
- create mode 100644 package/erlang/28.4.1/0001-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/26.2.5.19/0001-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/26.2.5.19/0002-erlang-libei-arch-compile.patch
+ create mode 100644 package/erlang/27.3.4.10/0001-disksup-update-df-call-to-work-with-Busybox.patch
+ create mode 100644 package/erlang/28.4.2/0001-disksup-update-df-call-to-work-with-Busybox.patch
 
 diff --git a/package/erlang/21.3.8.24/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch b/package/erlang/21.3.8.24/0001-erts-ethread-instruct-libatomic_ops-we-do-require-CA.patch
 new file mode 100644
@@ -957,11 +957,11 @@ index 0000000000..97f410b18c
 +-- 
 +2.25.1
 +
-diff --git a/package/erlang/26.2.5/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/26.2.5/0001-disksup-update-df-call-to-work-with-Busybox.patch
+diff --git a/package/erlang/26.2.5.19/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/26.2.5.19/0001-disksup-update-df-call-to-work-with-Busybox.patch
 new file mode 100644
 index 0000000000..9cccce73ac
 --- /dev/null
-+++ b/package/erlang/26.2.5/0001-disksup-update-df-call-to-work-with-Busybox.patch
++++ b/package/erlang/26.2.5.19/0001-disksup-update-df-call-to-work-with-Busybox.patch
 @@ -0,0 +1,77 @@
 +From 59f0d61699350a6df661c838a502a566b1c02768 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1040,11 +1040,11 @@ index 0000000000..9cccce73ac
 +-- 
 +2.34.1
 +
-diff --git a/package/erlang/26.2.5/0002-erlang-libei-arch-compile.patch b/package/erlang/26.2.5/0002-erlang-libei-arch-compile.patch
+diff --git a/package/erlang/26.2.5.19/0002-erlang-libei-arch-compile.patch b/package/erlang/26.2.5.19/0002-erlang-libei-arch-compile.patch
 new file mode 100644
 index 0000000000..5a3c729289
 --- /dev/null
-+++ b/package/erlang/26.2.5/0002-erlang-libei-arch-compile.patch
++++ b/package/erlang/26.2.5.19/0002-erlang-libei-arch-compile.patch
 @@ -0,0 +1,31 @@
 +From 442b23d9dd8d5d66fe70ceef31be7531ac75fa56 Mon Sep 17 00:00:00 2001
 +From: Ray Chang <ray@rclabs.org>
@@ -1077,11 +1077,11 @@ index 0000000000..5a3c729289
 +--
 +2.44.0
 +
-diff --git a/package/erlang/27.3.4.3/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/27.3.4.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
+diff --git a/package/erlang/27.3.4.10/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/27.3.4.10/0001-disksup-update-df-call-to-work-with-Busybox.patch
 new file mode 100644
 index 0000000000..b621381b4c
 --- /dev/null
-+++ b/package/erlang/27.3.4.3/0001-disksup-update-df-call-to-work-with-Busybox.patch
++++ b/package/erlang/27.3.4.10/0001-disksup-update-df-call-to-work-with-Busybox.patch
 @@ -0,0 +1,77 @@
 +From e85fabb333c9c03bf8b69c6edf49413a57fd5e86 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1160,11 +1160,11 @@ index 0000000000..b621381b4c
 +-- 
 +2.34.1
 +
-diff --git a/package/erlang/28.4.1/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/28.4.1/0001-disksup-update-df-call-to-work-with-Busybox.patch
+diff --git a/package/erlang/28.4.2/0001-disksup-update-df-call-to-work-with-Busybox.patch b/package/erlang/28.4.2/0001-disksup-update-df-call-to-work-with-Busybox.patch
 new file mode 100644
 index 0000000000..8e30ef0365
 --- /dev/null
-+++ b/package/erlang/28.4.1/0001-disksup-update-df-call-to-work-with-Busybox.patch
++++ b/package/erlang/28.4.2/0001-disksup-update-df-call-to-work-with-Busybox.patch
 @@ -0,0 +1,57 @@
 +From aa48235ab5f561d78894e70cd84f853f9eaa2423 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -1293,12 +1293,12 @@ index 7ff587e35c..f681b5db14 100644
 @@ -1,5 +1,19 @@
 -# From https://github.com/erlang/otp/releases/download/OTP-26.2.5.15/SHA256.txt
 -sha256  28e6d63d82927f132d56289dd3c428ef8bce6bf2283c8549aa0a7afca1a8fe3b  otp_src_26.2.5.15.tar.gz
-+# From https://github.com/erlang/otp/releases/download/OTP-28.4.1/SHA256.txt
-+sha256  fb2aa0bd8d4118a275895d4a0ea5b24e40e9e1e27a7b29e001377d7660fd9ecf  otp_src_28.4.1.tar.gz
-+# From https://github.com/erlang/otp/releases/download/OTP-27.3.4.3/SHA256.txt
-+sha256  597618c75890e8e606033bc8dbf6ec87fdf4e892c10b4912ae3c9a4f01384579  otp_src_27.3.4.3.tar.gz
-+# From https://github.com/erlang/otp/releases/download/OTP-26.2.5/SHA256.txt
-+sha256  de155c4ad9baab2b9e6c96dbd03bf955575a04dd6feee9c08758beb28484c9f6  otp_src_26.2.5.tar.gz
++# From https://github.com/erlang/otp/releases/download/OTP-28.4.2/SHA256.txt
++sha256  0c44346dd939f9d264860e5bdf4df8cd35e165b628a838d5d104c3b4cf65b9b0  otp_src_28.4.2.tar.gz
++# From https://github.com/erlang/otp/releases/download/OTP-27.3.4.10/SHA256.txt
++sha256  c93905c73ddb7afdfc7f0a46c33f95590eeffe9c2a8c75086d24bb9fe8abe029  otp_src_27.3.4.10.tar.gz
++# From https://github.com/erlang/otp/releases/download/OTP-26.2.5.19/SHA256.txt
++sha256  7fcfef4a838f15fea74f92ed498cad47bfe937d1cbda1e6471b0fcf98e56f3e8  otp_src_26.2.5.19.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-25.3.2/SHA256.txt
 +sha256  aed4e4726cdc587ab820c8379d63e511e46a1b1cc0c59d6a720b51ae625b2510  otp_src_25.3.2.tar.gz
 +# From https://github.com/erlang/otp/releases/download/OTP-24.3.2/SHA256.txt
@@ -1343,15 +1343,15 @@ index 3472f4119d..561076dd89 100644
 +ERLANG_ERTS_VSN = 13.2.2
 +else
 +ifeq ($(BR2_PACKAGE_ERLANG_26),y)
-+ERLANG_VERSION = 26.2.5
-+ERLANG_ERTS_VSN = 14.2.5
++ERLANG_VERSION = 26.2.5.19
++ERLANG_ERTS_VSN = 14.2.5.13
 +else
 +ifeq ($(BR2_PACKAGE_ERLANG_27),y)
-+ERLANG_VERSION = 27.3.4.3
-+ERLANG_ERTS_VSN = 15.2.7.2
++ERLANG_VERSION = 27.3.4.10
++ERLANG_ERTS_VSN = 15.2.7.7
 +else
-+ERLANG_VERSION = 28.4.1
-+ERLANG_ERTS_VSN = 16.3
++ERLANG_VERSION = 28.4.2
++ERLANG_ERTS_VSN = 16.3.1
 +endif
 +endif
 +endif

--- a/patches/buildroot/0015-erlang-use-available-memory-for-used-memory-calculat.patch
+++ b/patches/buildroot/0015-erlang-use-available-memory-for-used-memory-calculat.patch
@@ -7,14 +7,14 @@ Subject: [PATCH] erlang: use available memory for used memory calculation
  ...able-memory-on-Linux-for-used-memory.patch | 79 +++++++++++++++++++
  ...able-memory-on-Linux-for-used-memory.patch | 79 +++++++++++++++++++
  2 files changed, 158 insertions(+)
- create mode 100644 package/erlang/27.3.4.3/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
- create mode 100644 package/erlang/28.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+ create mode 100644 package/erlang/27.3.4.10/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+ create mode 100644 package/erlang/28.4.2/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
 
-diff --git a/package/erlang/27.3.4.3/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch b/package/erlang/27.3.4.3/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+diff --git a/package/erlang/27.3.4.10/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch b/package/erlang/27.3.4.10/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
 new file mode 100644
 index 0000000000..9922e5c58d
 --- /dev/null
-+++ b/package/erlang/27.3.4.3/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
++++ b/package/erlang/27.3.4.10/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
 @@ -0,0 +1,79 @@
 +From 3ee931e8acf916653bdc329f0543d415ccdc7326 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>
@@ -95,11 +95,11 @@ index 0000000000..9922e5c58d
 +-- 
 +2.43.0
 +
-diff --git a/package/erlang/28.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch b/package/erlang/28.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
+diff --git a/package/erlang/28.4.2/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch b/package/erlang/28.4.2/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
 new file mode 100644
 index 0000000000..0a71c25069
 --- /dev/null
-+++ b/package/erlang/28.4.1/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
++++ b/package/erlang/28.4.2/0002-memsup-use-available-memory-on-Linux-for-used-memory.patch
 @@ -0,0 +1,79 @@
 +From bd3c5eb3141a8fe243346387a14a7e38c5af8238 Mon Sep 17 00:00:00 2001
 +From: Frank Hunleth <fhunleth@troodon-software.com>

--- a/support/docker/nerves_system_br/Dockerfile
+++ b/support/docker/nerves_system_br/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: CC0-1.0
-FROM hexpm/erlang:28.4.1-ubuntu-noble-20260210.1
+FROM hexpm/erlang:28.4.2-ubuntu-noble-20260324
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
       description="Container with everything needed to build Nerves Systems"


### PR DESCRIPTION
Automated OTP patch release bumps.

- OTP-26: 26.2.5 -> 26.2.5.19
- OTP-27: 27.3.4.3 -> 27.3.4.10
- OTP-28: 28.4.1 -> 28.4.2

Generated by `update-erlang.sh`.