### PR TITLE
Activate imx500 camera to enable AI for rpicam tool

### DIFF
--- a/package/rpicam-apps/rpicam-apps.mk
+++ b/package/rpicam-apps/rpicam-apps.mk
@@ -19,7 +19,8 @@ RPICAM_APPS_DEPENDENCIES = \
 
 RPICAM_APPS_CONF_OPTS = \
 	-Denable_opencv=disabled \
-	-Denable_tflite=disabled
+	-Denable_tflite=disabled \
+	-Denable_imx500=true
 
 ifeq ($(BR2_PACKAGE_LIBDRM),y)
 RPICAM_APPS_DEPENDENCIES += libdrm


### PR DESCRIPTION
We should also enable opencv but that seem to be a big one to ship with buildroot system