### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1059,7 +1059,7 @@ notification below in addition to the following.
 
 This is primarily a bug fix release for Buildroot and Erlang/OTP. The Erlinit
 update brings in beta support for including a
-[`runtime.exs`](https://hexdocs.pm/mix/1.12.2/Mix.Tasks.Release.html#module-runtime-configuration)
+[`runtime.exs`](https://mix.hexdocs.pm/1.12.2/Mix.Tasks.Release.html#module-runtime-configuration)
 in your project. This support is new and may lead to reboot loops if you have
 not configured your system to revert to previous firmware loads on failures.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Nerves System BR provides the common logic for building Nerves Systems using
 [Buildroot](https://buildroot.org/). If you're new to Nerves, you probably don't
 want to look at this repository. Please check out the official
-[documentation](https://hexdocs.pm/nerves/getting-started.html).
+[documentation](https://nerves.hexdocs.pm/getting-started.html).
 
 For examples of using `nerves_system_br`, take a look at the officially
 supported hardware systems:


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves.hexdocs.pm/getting-started.html): Status 301
⚠️ Verification finished: 1 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>