### PR TITLE
libunistring: bump to 1.4.2 to fix host glibc 2.43 compilation

### DIFF
--- a/patches/buildroot/0019-packages-libunistring-bump-to-version-1.4.2.patch
+++ b/patches/buildroot/0019-packages-libunistring-bump-to-version-1.4.2.patch
@@ -1,0 +1,44 @@
+From 9123849e0e39e54fcaf68597dd038bc60f06eabe Mon Sep 17 00:00:00 2001
+From: Paul Kocialkowski <paulk@sys-base.io>
+Date: Wed, 25 Feb 2026 18:51:38 +0100
+Subject: [PATCH] packages/libunistring: bump to version 1.4.2
+
+This minor release contains a fix for building with host glibc 2.43,
+which fails otherwise.
+
+Signed-off-by: Paul Kocialkowski <paulk@sys-base.io>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+---
+ package/libunistring/libunistring.hash | 4 ++--
+ package/libunistring/libunistring.mk   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/package/libunistring/libunistring.hash b/package/libunistring/libunistring.hash
+index f86b6f94b0..ef2f3da341 100644
+--- a/package/libunistring/libunistring.hash
++++ b/package/libunistring/libunistring.hash
+@@ -1,6 +1,6 @@
+ # Locally calculated after checking pgp signature
+-# https://ftp.gnu.org/gnu/libunistring/libunistring-1.4.1.tar.xz.sig
+-sha256  67d88430892527861903788868c77802a217b0959990f7449f2976126a307763  libunistring-1.4.1.tar.xz
++# https://ftp.gnu.org/gnu/libunistring/libunistring-1.4.2.tar.xz.sig
++sha256  5b46e74377ed7409c5b75e7a96f95377b095623b689d8522620927964a41499c  libunistring-1.4.2.tar.xz
+ # Locally calculated
+ sha256  3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  COPYING
+ sha256  a853c2ffec17057872340eee242ae4d96cbf2b520ae27d903e1b2fef1a5f9d1c  COPYING.LIB
+diff --git a/package/libunistring/libunistring.mk b/package/libunistring/libunistring.mk
+index 1abbfde6da..57333a35bf 100644
+--- a/package/libunistring/libunistring.mk
++++ b/package/libunistring/libunistring.mk
+@@ -4,7 +4,7 @@
+ #
+ ################################################################################
+ 
+-LIBUNISTRING_VERSION = 1.4.1
++LIBUNISTRING_VERSION = 1.4.2
+ LIBUNISTRING_SITE = $(BR2_GNU_MIRROR)/libunistring
+ LIBUNISTRING_SOURCE = libunistring-$(LIBUNISTRING_VERSION).tar.xz
+ LIBUNISTRING_INSTALL_STAGING = YES
+-- 
+2.53.0
+


### PR DESCRIPTION
This fixes a compilation error on Ubuntu 26.04 and any other glibc 2.43 host.