### PR TITLE
Add rpi-utils buildroot package

### DIFF
--- a/patches/buildroot/0018-package-rpi-utils-new-package.patch
+++ b/patches/buildroot/0018-package-rpi-utils-new-package.patch
@@ -1,0 +1,84 @@
+From 9af9119f451d4b1441b75627f489669d734288e0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ga=C3=ABl=20PORTAY?= <gael.portay@rtone.fr>
+Date: Thu, 15 May 2025 12:00:00 +0000
+Subject: [PATCH] package/rpi-utils: new package
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add the rpi-utils package, a collection of scripts and simple
+applications for the Raspberry Pi (vcgencmd, vcmailbox, etc.). This
+replaces the tools previously provided by the now-removed rpi-userland
+package.
+
+Upstream submission:
+https://patchwork.ozlabs.org/project/buildroot/patch/20250515-package-rpi-utils-new-package-v3-1-2@rtone.fr/
+
+Signed-off-by: Gaël PORTAY <gael.portay@rtone.fr>
+
+diff --git a/package/Config.in b/package/Config.in
+index 371a1c33..240dd4ae 100644
+--- a/package/Config.in
++++ b/package/Config.in
+@@ -447,6 +447,7 @@ menu "Firmware"
+ 	source "package/qoriq-restool/Config.in"
+ 	source "package/rcw-smarc-sal28/Config.in"
+ 	source "package/rpi-firmware/Config.in"
++	source "package/rpi-utils/Config.in"
+ 	source "package/sunxi-boards/Config.in"
+ 	source "package/ts4900-fpga/Config.in"
+ 	source "package/ux500-firmware/Config.in"
+diff --git a/package/rpi-utils/Config.in b/package/rpi-utils/Config.in
+new file mode 100644
+index 00000000..a2729167
+--- /dev/null
++++ b/package/rpi-utils/Config.in
+@@ -0,0 +1,12 @@
++config BR2_PACKAGE_RPI_UTILS
++	bool "rpi-utils"
++	depends on !BR2_STATIC_LIBS # dtc
++	select BR2_PACKAGE_DTC
++	help
++	  A collection of scripts and simple applications for the
++	  Raspberry Pi.
++
++	  https://github.com/raspberrypi/utils/
++
++comment "rpi-utils needs a toolchain w/ dynamic library"
++	depends on BR2_STATIC_LIBS
+diff --git a/package/rpi-utils/rpi-utils.hash b/package/rpi-utils/rpi-utils.hash
+new file mode 100644
+index 00000000..a6612373
+--- /dev/null
++++ b/package/rpi-utils/rpi-utils.hash
+@@ -0,0 +1,3 @@
++# Locally computed
++sha256  c35932e501b43e5fb48cfc488aadc4a8bbceb0e9e6dafdf6c7cd2066b58acd61  rpi-utils-a1d522f0f1b50858a44fac80523a2bd80098e789.tar.gz
++sha256  731da956431d1a7c5073e7ee5ebe01f54e359c5339310b32f0893c6fe6507d5a  LICENCE
+diff --git a/package/rpi-utils/rpi-utils.mk b/package/rpi-utils/rpi-utils.mk
+new file mode 100644
+index 00000000..49db3aef
+--- /dev/null
++++ b/package/rpi-utils/rpi-utils.mk
+@@ -0,0 +1,18 @@
++################################################################################
++#
++# rpi-utils
++#
++################################################################################
++
++RPI_UTILS_VERSION = a1d522f0f1b50858a44fac80523a2bd80098e789
++RPI_UTILS_SITE = $(call github,raspberrypi,utils,$(RPI_UTILS_VERSION))
++RPI_UTILS_LICENSE = BSD-3-Clause
++RPI_UTILS_LICENSE_FILES = LICENCE
++RPI_UTILS_INSTALL_STAGING = YES
++RPI_UTILS_DEPENDENCIES = dtc
++
++# Ensure the internal dtovl remains an archive object and it is not built as a
++# dynamic library that is linked by other utilities; as it is not installed.
++RPI_UTILS_CONF_OPTS = -DSTATIC=STATIC
++
++$(eval $(cmake-package))
+-- 
+2.53.0
+


### PR DESCRIPTION
Adds a buildroot patch (package/rpi-utils) providing the modern Raspberry Pi utilities (vcgencmd, vcmailbox, etc.) as a replacement for the removed rpi-userland tools. Enable with BR2_PACKAGE_RPI_UTILS=y.

Patch taken from the upstream buildroot submission (v3 1/2).

Pulled together using Claude, verified on device and looked okay to my eyeballs but I don't read buildroot packages often enough so very open to adjustments.